### PR TITLE
Fix sort logic misuse in RegulacaoLeitos

### DIFF
--- a/src/components/PacientesAguardandoRegulacao.tsx
+++ b/src/components/PacientesAguardandoRegulacao.tsx
@@ -23,7 +23,6 @@ interface PacientesAguardandoRegulacaoProps {
     setResumoModalOpen: (open: boolean) => void;
   };
   filtrosProps: {
-    filteredPacientes: any[];
     sortConfig: { key: string; direction: string };
   };
 }

--- a/src/pages/RegulacaoLeitos.tsx
+++ b/src/pages/RegulacaoLeitos.tsx
@@ -4,7 +4,6 @@ import { Badge } from "@/components/ui/badge";
 import { AcoesRapidas } from "@/components/AcoesRapidas";
 import { RegulacaoModals } from "@/components/modals/regulacao/RegulacaoModals";
 import { useRegulacaoLogic } from "@/hooks/useRegulacaoLogic";
-import { useFiltrosRegulacao } from "@/hooks/useFiltrosRegulacao";
 import { useState } from "react";
 
 // Componentes atualizados
@@ -28,14 +27,6 @@ const RegulacaoLeitos = () => {
     filtrosProps,
   } = useRegulacaoLogic();
 
-  // Use the filter hook to get filtered patients
-  const todosPacientesPendentes = [
-    ...listas.decisaoCirurgica,
-    ...listas.decisaoClinica,
-    ...listas.recuperacaoCirurgica
-  ];
-
-  const { filteredPacientes } = useFiltrosRegulacao(todosPacientesPendentes);
 
   // Estados para os novos modais de panorama
   const [panoramaSelecaoOpen, setPanoramaSelecaoOpen] = useState(false);
@@ -125,7 +116,6 @@ const RegulacaoLeitos = () => {
             setResumoModalOpen: handlers.setResumoModalOpen
           }}
           filtrosProps={{
-            filteredPacientes: filteredPacientes,
             sortConfig: filtrosProps.sortConfig
           }}
         />


### PR DESCRIPTION
## Summary
- stop using an extra `useFiltrosRegulacao` inside `RegulacaoLeitos`
- drop unused `filteredPacientes` prop from `PacientesAguardandoRegulacao`

## Testing
- `npm run lint` *(fails: could not resolve @eslint/js and many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68887317690483229a9501a8ce991e19