### PR TITLE
feat: add homonym regulation warning

### DIFF
--- a/src/components/modals/JustificativaHomonimoModal.tsx
+++ b/src/components/modals/JustificativaHomonimoModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Textarea } from '@/components/ui/textarea';
+
+interface JustificativaHomonimoModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (justificativa: string) => void;
+  pacienteNome: string;
+  leitoCodigo: string;
+}
+
+export const JustificativaHomonimoModal = ({
+  open,
+  onOpenChange,
+  onConfirm,
+  pacienteNome,
+  leitoCodigo,
+}: JustificativaHomonimoModalProps) => {
+  const [justificativa, setJustificativa] = useState('');
+
+  const handleConfirm = () => {
+    onConfirm(justificativa);
+    setJustificativa('');
+  };
+
+  const handleOpenChange = (o: boolean) => {
+    if (!o) setJustificativa('');
+    onOpenChange(o);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Justificativa Obrigatória</AlertDialogTitle>
+          <AlertDialogDescription>
+            Você está regulando "{pacienteNome}" para o leito {leitoCodigo}, que já contém um paciente homônimo. Por favor,
+            justifique o motivo para prosseguir.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Textarea
+          value={justificativa}
+          onChange={e => setJustificativa(e.target.value)}
+          placeholder="Descreva a justificativa..."
+          className="mt-4"
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm} disabled={!justificativa.trim()}>
+            Confirmar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/modals/RegulacaoModal.tsx
+++ b/src/components/modals/RegulacaoModal.tsx
@@ -7,12 +7,18 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { AlertTriangle, Copy, CheckCircle, BedDouble } from 'lucide-react';
+import { AlertTriangle, Copy, CheckCircle, BedDouble, Users2 } from 'lucide-react';
 import { Paciente } from '@/types/hospital'; // CORREÇÃO: Importa o tipo correto
-import { useLeitoFinder } from '@/hooks/useLeitoFinder';
+import { useLeitoFinder, LeitoCompativel } from '@/hooks/useLeitoFinder';
 import { useToast } from '@/hooks/use-toast';
 import { ScrollArea } from '../ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface RegulacaoModalProps {
   open: boolean;
@@ -36,8 +42,8 @@ const calcularIdade = (dataNascimento?: string): string => {
 export const RegulacaoModal = ({ open, onOpenChange, paciente, origem, onConfirmRegulacao, isAlteracao = false, modo = 'normal' }: RegulacaoModalProps) => {
   const { findAvailableLeitos } = useLeitoFinder();
   const { toast } = useToast();
-  const [leitosDisponiveis, setLeitosDisponiveis] = useState<any[]>([]);
-  const [leitoSelecionado, setLeitoSelecionado] = useState<any | null>(null);
+  const [leitosDisponiveis, setLeitosDisponiveis] = useState<LeitoCompativel[]>([]);
+  const [leitoSelecionado, setLeitoSelecionado] = useState<LeitoCompativel | null>(null);
   const [etapa, setEtapa] = useState(1);
   const [observacoes, setObservacoes] = useState('');
   const [motivoAlteracao, setMotivoAlteracao] = useState('');
@@ -75,10 +81,10 @@ export const RegulacaoModal = ({ open, onOpenChange, paciente, origem, onConfirm
     return leitosDisponiveis.reduce((acc, leito) => {
       (acc[leito.setorNome] = acc[leito.setorNome] || []).push(leito);
       return acc;
-    }, {} as Record<string, any[]>);
+    }, {} as Record<string, LeitoCompativel[]>);
   }, [leitosDisponiveis]);
 
-  const handleSelectLeito = (leito: any) => {
+  const handleSelectLeito = (leito: LeitoCompativel) => {
     setLeitoSelecionado(leito);
     setEtapa(isAlteracao ? 3 : 2);
   };
@@ -204,9 +210,9 @@ Data e hora da regulação: ${new Date().toLocaleString('pt-BR')}`;
                       </div>
                     </AccordionTrigger>
                     <AccordionContent className="space-y-2">
-                      {(leitos as any[]).map(leito => (
-                        <Card 
-                          key={leito.id} 
+                      {(leitos as LeitoCompativel[]).map(leito => (
+                        <Card
+                          key={leito.id}
                           className="cursor-pointer hover:bg-muted/50 transition-colors"
                           onClick={() => handleSelectLeito(leito)}
                         >
@@ -217,6 +223,23 @@ Data e hora da regulação: ${new Date().toLocaleString('pt-BR')}`;
                                 <span className="font-medium">{leito.codigoLeito}</span>
                                 {leito.leitoPCP && <Badge variant="outline">PCP</Badge>}
                                 {leito.leitoIsolamento && <Badge variant="destructive">Isolamento</Badge>}
+                                {leito.temHomonimo && (
+                                  <TooltipProvider>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <Badge variant="destructive" className="flex items-center gap-1">
+                                          <Users2 className="h-3 w-3" />
+                                        </Badge>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>
+                                          Alerta: Já existe um paciente com o mesmo primeiro nome neste
+                                          quarto.
+                                        </p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </TooltipProvider>
+                                )}
                               </div>
                               <Badge variant={leito.statusLeito === 'Vago' ? 'default' : 'secondary'}>
                                 {leito.statusLeito}

--- a/src/hooks/useRegulacaoLogic.ts
+++ b/src/hooks/useRegulacaoLogic.ts
@@ -93,7 +93,7 @@ const registrarHistoricoRegulacao = async (
     };
 
     if (tipoEvento === 'criada') {
-        const docRef = await addDoc(collection(db, "regulacoesRegulaFacil"), {
+        const payload: any = {
             pacienteId: dados.paciente.id,
             pacienteNome: dados.paciente.nomeCompleto,
             setorOrigemNome: dados.paciente.setorOrigem,
@@ -105,7 +105,11 @@ const registrarHistoricoRegulacao = async (
             criadaEm: agora,
             criadaPor: usuario,
             historicoEventos: [evento],
-        });
+        };
+        if (dados.justificativaHomonimo) {
+            payload.justificativaHomonimo = dados.justificativaHomonimo;
+        }
+        const docRef = await addDoc(collection(db, "regulacoesRegulaFacil"), payload);
         return docRef.id;
     }
 
@@ -458,7 +462,8 @@ const registrarHistoricoRegulacao = async (
   const handleConfirmarRegulacao = async (
     leitoDestino: any,
     observacoes: string,
-    motivoAlteracao?: string
+    motivoAlteracao?: string,
+    justificativaHomonimo?: string
   ) => {
       if (!userData) {
           toast({ title: "Aguarde", description: "Carregando dados do usuário...", variant: "default" });
@@ -494,6 +499,7 @@ const registrarHistoricoRegulacao = async (
                 paciente: pacienteParaRegular,
                 leitoDestino: leitoDestino,
                 modoRegulacao: modoRegulacao,
+                justificativaHomonimo,
                 detalhesLog: `Regulou ${pacienteParaRegular.nomeCompleto} para o leito ${leitoDestino.codigoLeito}.`,
             });
         }
@@ -521,7 +527,13 @@ const registrarHistoricoRegulacao = async (
             });
         }
 
-        registrarLog(logMessage || `Regulou ${pacienteParaRegular.nomeCompleto} para o leito ${leitoDestino.codigoLeito}.`, "Regulação de Leitos");
+        const baseLog =
+          logMessage ||
+          `Regulou ${pacienteParaRegular.nomeCompleto} para o leito ${leitoDestino.codigoLeito}.`;
+        const logComJustificativa = justificativaHomonimo
+          ? `${baseLog} Justificativa homônimo: ${justificativaHomonimo}`
+          : baseLog;
+        registrarLog(logComJustificativa, "Regulação de Leitos");
         toast({ title: isAlteracaoMode ? "Alteração Confirmada!" : "Regulação Confirmada!", description: "A mensagem foi copiada para a área de transferência." });
 
         setRegulacaoModalOpen(false);

--- a/src/hooks/useRegulacoes.ts
+++ b/src/hooks/useRegulacoes.ts
@@ -2,16 +2,7 @@
 import { useState, useEffect } from 'react';
 import { collection, query, onSnapshot, orderBy } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-
-export interface Regulacao {
-  id: string;
-  status: 'Pendente' | 'Concluída' | 'Cancelada';
-  criadaEm: string; // ISO string
-  concluidaEm?: string; // ISO string
-  setorOrigemNome: string;
-  setorDestinoNome: string;
-  historicoEventos: Array<{ evento: string; timestamp: string }>;
-}
+import { Regulacao } from '@/types/hospital';
 
 export const useRegulacoes = () => {
   const [regulacoes, setRegulacoes] = useState<Regulacao[]>([]);

--- a/src/pages/RegulacaoLeitos.tsx
+++ b/src/pages/RegulacaoLeitos.tsx
@@ -21,6 +21,7 @@ import { RemanejamentosPendentesBloco } from "@/components/RemanejamentosPendent
 // Novos modals
 import { PanoramaSelecaoPeriodoModal } from "@/components/modals/PanoramaSelecaoPeriodoModal";
 import { PanoramaVisualizacaoModal } from "@/components/modals/PanoramaVisualizacaoModal";
+import { JustificativaHomonimoModal } from "@/components/modals/JustificativaHomonimoModal";
 
 const RegulacaoLeitos = () => {
   const { loading, listas, modals, handlers, filtrosProps } = useRegulacaoLogic();
@@ -34,6 +35,12 @@ const RegulacaoLeitos = () => {
     inicio: "",
     fim: "",
   });
+  const [justificativaOpen, setJustificativaOpen] = useState(false);
+  const [regulacaoPendente, setRegulacaoPendente] = useState<{
+    leitoDestino: any;
+    observacoes: string;
+    motivoAlteracao?: string;
+  } | null>(null);
 
   const handleAbrirPanorama = () => {
     setPanoramaSelecaoOpen(true);
@@ -42,6 +49,32 @@ const RegulacaoLeitos = () => {
   const handleGerarPanorama = (dataInicio: string, dataFim: string) => {
     setPeriodoSelecionado({ inicio: dataInicio, fim: dataFim });
     setPanoramaVisualizacaoOpen(true);
+  };
+
+  const handleConfirmarRegulacao = (
+    leitoDestino: any,
+    observacoes: string,
+    motivoAlteracao?: string
+  ) => {
+    if (leitoDestino.temHomonimo) {
+      setRegulacaoPendente({ leitoDestino, observacoes, motivoAlteracao });
+      setJustificativaOpen(true);
+    } else {
+      handlers.handleConfirmarRegulacao(leitoDestino, observacoes, motivoAlteracao);
+    }
+  };
+
+  const handleConfirmarJustificativa = (justificativa: string) => {
+    if (regulacaoPendente) {
+      handlers.handleConfirmarRegulacao(
+        regulacaoPendente.leitoDestino,
+        regulacaoPendente.observacoes,
+        regulacaoPendente.motivoAlteracao,
+        justificativa
+      );
+      setRegulacaoPendente(null);
+    }
+    setJustificativaOpen(false);
   };
 
   // Substitua todo este bloco 'useMemo' pelo novo código
@@ -288,7 +321,7 @@ const RegulacaoLeitos = () => {
           totalPendentes={listas.totalPendentes}
           onProcessFileRequest={handlers.handleProcessFileRequest}
           onConfirmSync={handlers.handleConfirmSync}
-          onConfirmarRegulacao={handlers.handleConfirmarRegulacao}
+          onConfirmarRegulacao={handleConfirmarRegulacao}
           onConfirmarCancelamento={handlers.onConfirmarCancelamento}
           onConfirmarTransferenciaExterna={
             handlers.handleConfirmarTransferenciaExterna
@@ -302,6 +335,17 @@ const RegulacaoLeitos = () => {
           setGerenciarTransferenciaOpen={handlers.setGerenciarTransferenciaOpen}
           setResumoModalOpen={handlers.setResumoModalOpen}
           setSugestoesModalOpen={handlers.setSugestoesModalOpen}
+        />
+
+        <JustificativaHomonimoModal
+          open={justificativaOpen}
+          onOpenChange={(open) => {
+            if (!open) setRegulacaoPendente(null);
+            setJustificativaOpen(open);
+          }}
+          onConfirm={handleConfirmarJustificativa}
+          pacienteNome={modals.pacienteParaRegular?.nomeCompleto || ''}
+          leitoCodigo={regulacaoPendente?.leitoDestino.codigoLeito || ''}
         />
 
         {/* Novos Modais de Panorama */}

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -131,6 +131,18 @@ export interface SolicitacaoCirurgicaFormData {
   dataPrevisaCirurgia: Date;
 }
 
+// Informações básicas das regulações para listagens e auditoria
+export interface Regulacao {
+  id: string;
+  status: 'Pendente' | 'Concluída' | 'Cancelada';
+  criadaEm: string; // ISO string
+  concluidaEm?: string; // ISO string
+  setorOrigemNome: string;
+  setorDestinoNome: string;
+  historicoEventos: Array<{ evento: string; timestamp: string }>;
+  justificativaHomonimo?: string;
+}
+
 // Alias for backward compatibility
 export interface DadosPaciente extends Paciente {}
 export interface HistoricoMovimentacao extends HistoricoLeito {}


### PR DESCRIPTION
## Summary
- detect homonymous patients when listing compatible beds
- warn about homonymous patients and require justification for regulation
- store justification and audit log for homonym regulation events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9dec87f08322b893e9c63ec69ee8