### PR TITLE
feat: adicionar relatório de ocupação por especialidade

### DIFF
--- a/src/components/AcoesRapidas.tsx
+++ b/src/components/AcoesRapidas.tsx
@@ -6,7 +6,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { Download, FileText, Lightbulb, BarChart3 } from 'lucide-react';
+import { Download, FileText, Lightbulb, BarChart3, Stethoscope } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface AcoesRapidasProps {
@@ -14,16 +14,18 @@ interface AcoesRapidasProps {
   onPassagemClick?: () => void;
   onSugestoesClick?: () => void;
   onPanoramaClick?: () => void;
+  onRelatorioEspecialidadeClick?: () => void;
   showAllButtons?: boolean;
   sugestoesDisponiveis?: boolean;
   panoramaDisponivel?: boolean;
 }
 
-export const AcoesRapidas = ({ 
-  onImportarClick, 
-  onPassagemClick, 
+export const AcoesRapidas = ({
+  onImportarClick,
+  onPassagemClick,
   onSugestoesClick,
   onPanoramaClick,
+  onRelatorioEspecialidadeClick,
   showAllButtons = false,
   sugestoesDisponiveis = false,
   panoramaDisponivel = false
@@ -45,6 +47,23 @@ export const AcoesRapidas = ({
             <p>Importar pacientes MV</p>
           </TooltipContent>
         </Tooltip>
+
+        {onRelatorioEspecialidadeClick && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={onRelatorioEspecialidadeClick}
+              >
+                <Stethoscope className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Ocupação por Especialidade</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
 
         {showAllButtons && (
           <>

--- a/src/components/modals/RelatorioEspecialidadeModal.tsx
+++ b/src/components/modals/RelatorioEspecialidadeModal.tsx
@@ -1,0 +1,41 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+
+interface RelatorioEspecialidadeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  dadosOcupacao: Record<string, number>;
+}
+
+export const RelatorioEspecialidadeModal = ({ open, onOpenChange, dadosOcupacao }: RelatorioEspecialidadeModalProps) => {
+  const entries = Object.entries(dadosOcupacao).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Ocupação por Especialidade</DialogTitle>
+          <DialogDescription>
+            Quantidade de pacientes internados por especialidade.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="max-h-72 pr-4">
+          {entries.length > 0 ? (
+            <ul className="space-y-2">
+              {entries.map(([especialidade, contagem]) => (
+                <li key={especialidade} className="flex items-center justify-between">
+                  <span>{especialidade}</span>
+                  <Badge variant="secondary">{contagem}</Badge>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">Sem internações</p>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};
+


### PR DESCRIPTION
## Summary
- criar modal de relatório de ocupação por especialidade
- calcular ocupação por especialidade e exibir em novo botão de ações rápidas no mapa de leitos
- suportar botão de ocupação por especialidade no componente Ações Rápidas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68adac2eaaa88322add492e3082a9894