### PR TITLE
Add higienization priority toggle and discharge pending modal

### DIFF
--- a/src/components/LeitoCard.tsx
+++ b/src/components/LeitoCard.tsx
@@ -1,7 +1,7 @@
 // src/components/LeitoCard.tsx
 
 import { useState, useMemo } from 'react';
-import { Star, ShieldAlert, Lock, Paintbrush, Info, BedDouble, AlertTriangle, ArrowRightLeft, Unlock, User, Stethoscope, Ambulance, XCircle, CheckCircle, Move, LogOut, Bell, MessageSquarePlus, UserPlus, BookMarked } from 'lucide-react';
+import { Star, ShieldAlert, Lock, Paintbrush, Info, BedDouble, AlertTriangle, ArrowRightLeft, Unlock, User, Stethoscope, Ambulance, XCircle, CheckCircle, Move, LogOut, Bell, MessageSquarePlus, UserPlus, BookMarked, Siren, PlaneTakeoff } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -14,7 +14,7 @@ import { RemanejamentoModal } from './modals/RemanejamentoModal';
 import { TransferenciaModal } from './modals/TransferenciaModal';
 import { cn } from '@/lib/utils';
 import { LeitoStatusIsolamento } from './LeitoStatusIsolamento';
-import { LeitoEnriquecido } from '@/types/hospital';
+import { LeitoEnriquecido, InfoAltaPendente } from '@/types/hospital';
 
 interface LeitoCardProps {
   leito: LeitoEnriquecido;
@@ -31,6 +31,24 @@ const calcularIdade = (dataNascimento: string): string => {
     const m = hoje.getMonth() - nascimento.getMonth();
     if (m < 0 || (m === 0 && hoje.getDate() < nascimento.getDate())) idade--;
     return idade.toString();
+};
+
+const descreverAltaPendente = (info: InfoAltaPendente | null | undefined): string => {
+    if (!info) return '';
+    switch (info.tipo) {
+        case 'medicacao':
+            return `Finalizando medicação${info.detalhe ? ` às ${info.detalhe}` : ''}`;
+        case 'transporte':
+            return `Aguardando transporte${info.detalhe ? ` de ${info.detalhe}` : ''}`;
+        case 'familiar':
+            return 'Aguardando familiar';
+        case 'emad':
+            return 'Aguardando EMAD';
+        case 'outros':
+            return info.detalhe || 'Outros';
+        default:
+            return '';
+    }
 };
 
 const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
@@ -251,7 +269,27 @@ const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
             )}
             
             {leito.statusLeito === 'Higienizacao' && (
-              <div className="flex justify-center">
+              <div className="flex justify-center gap-1">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => actions.onPriorizarHigienizacao(leito.id, leito.prioridadeHigienizacao || false)}
+                      >
+                        <Siren
+                          className={`h-4 w-4 ${
+                            leito.prioridadeHigienizacao ? 'text-yellow-500 fill-yellow-500' : 'text-muted-foreground'
+                          }`}
+                        />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent><p>Prioridade de Higienização</p></TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+
                 <AlertDialog>
                   <TooltipProvider>
                     <Tooltip>
@@ -276,7 +314,7 @@ const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-              </div> 
+              </div>
             )}
             
             {leito.statusLeito === 'Reservado' && (
@@ -437,6 +475,28 @@ const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent><p>Sinalizar Provável Alta</p></TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => actions.onAltaPendente(paciente!)}
+                      >
+                        <PlaneTakeoff className={`h-4 w-4 ${paciente?.altaPendente ? 'text-blue-500' : ''}`} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        {paciente?.altaPendente
+                          ? descreverAltaPendente(paciente.altaPendente)
+                          : 'Registrar pendência de alta'}
+                      </p>
+                    </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               </div>

--- a/src/components/ListaHigienizacao.tsx
+++ b/src/components/ListaHigienizacao.tsx
@@ -9,7 +9,7 @@ interface LeitoHigienizacao {
   codigoLeito: string;
   tempoEsperaFormatado: string;
   tempoEsperaMinutos: number;
-  higienizacaoPrioritaria?: boolean;
+  prioridadeHigienizacao?: boolean;
   setor: string;
 }
 
@@ -48,13 +48,13 @@ const ListaHigienizacao = ({ leitosAgrupados, onConcluir }: ListaHigienizacaoPro
                 <div
                   key={leito.id}
                   className={`flex items-center justify-between p-3 rounded-lg border transition-all ${
-                    leito.higienizacaoPrioritaria
+                    leito.prioridadeHigienizacao
                       ? 'border-yellow-400 bg-yellow-50 shadow-md border-2'
                       : 'border-border bg-card hover:bg-muted/50'
                   }`}
                 >
                   <div className="flex items-center gap-3">
-                    {leito.higienizacaoPrioritaria && (
+                    {leito.prioridadeHigienizacao && (
                       <Star className="h-5 w-5 text-yellow-500 fill-yellow-500" />
                     )}
                     <div>
@@ -64,7 +64,7 @@ const ListaHigienizacao = ({ leitosAgrupados, onConcluir }: ListaHigienizacaoPro
                       <div className="flex items-center gap-2 text-sm text-muted-foreground">
                         <Clock className="h-4 w-4" />
                         <span>Aguardando há {leito.tempoEsperaFormatado}</span>
-                        {leito.higienizacaoPrioritaria && (
+                        {leito.prioridadeHigienizacao && (
                           <Badge variant="secondary" className="bg-yellow-100 text-yellow-800">
                             PRIORITÁRIO
                           </Badge>

--- a/src/components/modals/AltaPendenteModal.tsx
+++ b/src/components/modals/AltaPendenteModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { InfoAltaPendente } from '@/types/hospital';
+import { useAuth } from '@/hooks/useAuth';
+
+interface AltaPendenteModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (dados: InfoAltaPendente) => void;
+  pacienteNome: string;
+}
+
+const AltaPendenteModal = ({ open, onOpenChange, onConfirm, pacienteNome }: AltaPendenteModalProps) => {
+  const { userData } = useAuth();
+  const [tipo, setTipo] = useState<InfoAltaPendente['tipo']>('medicacao');
+  const [detalhe, setDetalhe] = useState('');
+
+  const resetar = () => {
+    setTipo('medicacao');
+    setDetalhe('');
+  };
+
+  const handleConfirm = () => {
+    const info: InfoAltaPendente = {
+      tipo,
+      detalhe: detalhe || undefined,
+      usuario: userData?.nomeCompleto || 'Usuário desconhecido',
+      timestamp: new Date().toISOString(),
+    };
+    onConfirm(info);
+    resetar();
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    resetar();
+    onOpenChange(false);
+  };
+
+  const confirmDisabled = () => {
+    if (tipo === 'medicacao' && !detalhe) return true;
+    if (tipo === 'transporte' && !detalhe.trim()) return true;
+    if (tipo === 'outros' && !detalhe.trim()) return true;
+    return false;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleCancel}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold text-medical-primary">
+            Pendência de Alta - {pacienteNome}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <RadioGroup
+            value={tipo}
+            onValueChange={(v) => {
+              setTipo(v as InfoAltaPendente['tipo']);
+              setDetalhe('');
+            }}
+            className="space-y-2"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="medicacao" id="medicacao" />
+              <Label htmlFor="medicacao">Finalizando Medicação</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="transporte" id="transporte" />
+              <Label htmlFor="transporte">Aguardando Transporte</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="familiar" id="familiar" />
+              <Label htmlFor="familiar">Aguardando Familiar</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="emad" id="emad" />
+              <Label htmlFor="emad">Aguardando EMAD</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="outros" id="outros" />
+              <Label htmlFor="outros">Outros</Label>
+            </div>
+          </RadioGroup>
+
+          {tipo === 'medicacao' && (
+            <div className="space-y-2">
+              <Label htmlFor="horaMedicacao">Horário da Medicação</Label>
+              <Input id="horaMedicacao" type="time" value={detalhe} onChange={(e) => setDetalhe(e.target.value)} />
+            </div>
+          )}
+          {tipo === 'transporte' && (
+            <div className="space-y-2">
+              <Label htmlFor="municipio">Município</Label>
+              <Input id="municipio" placeholder="Município..." value={detalhe} onChange={(e) => setDetalhe(e.target.value)} />
+            </div>
+          )}
+          {tipo === 'outros' && (
+            <div className="space-y-2">
+              <Label htmlFor="detalhe">Detalhe</Label>
+              <Textarea id="detalhe" value={detalhe} onChange={(e) => setDetalhe(e.target.value)} />
+            </div>
+          )}
+        </div>
+        <DialogFooter className="flex justify-end space-x-2">
+          <Button variant="outline" onClick={handleCancel}>Cancelar</Button>
+          <Button variant="medical" onClick={handleConfirm} disabled={confirmDisabled()}>
+            Confirmar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AltaPendenteModal;

--- a/src/hooks/useHigienizacao.ts
+++ b/src/hooks/useHigienizacao.ts
@@ -96,11 +96,11 @@ export const useHigienizacao = () => {
   // Separar leitos prioritários dos normais
   const { leitosPrioritarios, leitosNormais } = useMemo(() => {
     const prioritarios = leitosProcessados
-      .filter(leito => leito.higienizacaoPrioritaria)
+      .filter(leito => leito.prioridadeHigienizacao)
       .sort((a, b) => b.tempoEsperaMinutos - a.tempoEsperaMinutos);
 
     const normais = leitosProcessados
-      .filter(leito => !leito.higienizacaoPrioritaria)
+      .filter(leito => !leito.prioridadeHigienizacao)
       .sort((a, b) => b.tempoEsperaMinutos - a.tempoEsperaMinutos);
 
     return { leitosPrioritarios: prioritarios, leitosNormais: normais };
@@ -120,8 +120,8 @@ export const useHigienizacao = () => {
     Object.keys(grupos).forEach(setor => {
       grupos[setor].sort((a, b) => {
         // Primeiro prioridade, depois tempo
-        if (a.higienizacaoPrioritaria && !b.higienizacaoPrioritaria) return -1;
-        if (!a.higienizacaoPrioritaria && b.higienizacaoPrioritaria) return 1;
+        if (a.prioridadeHigienizacao && !b.prioridadeHigienizacao) return -1;
+        if (!a.prioridadeHigienizacao && b.prioridadeHigienizacao) return 1;
         return b.tempoEsperaMinutos - a.tempoEsperaMinutos;
       });
     });
@@ -188,16 +188,16 @@ export const useHigienizacao = () => {
         duracaoMinutos,
         usuarioIdConclusao: userData.uid,
         usuarioNomeConclusao: userData.nomeCompleto,
-        prioritaria: leito.higienizacaoPrioritaria || false
+        prioritaria: leito.prioridadeHigienizacao || false
       });
 
       // 2. Atualizar status do leito para Vago
       await atualizarStatusLeito(leito.id, 'Vago');
 
       // 3. Limpar flag de prioridade se existir
-      if (leito.higienizacaoPrioritaria) {
+      if (leito.prioridadeHigienizacao) {
         await updateDoc(doc(db, 'leitosRegulaFacil', leito.id), {
-          higienizacaoPrioritaria: false
+          prioridadeHigienizacao: false
         });
       }
 

--- a/src/hooks/useLeitos.ts
+++ b/src/hooks/useLeitos.ts
@@ -198,6 +198,22 @@ export const useLeitos = () => {
     }
   };
 
+  const togglePrioridadeHigienizacao = async (leitoId: string, prioridadeAtual: boolean) => {
+    try {
+      const leitoRef = doc(db, 'leitosRegulaFacil', leitoId);
+      await updateDoc(leitoRef, { prioridadeHigienizacao: !prioridadeAtual });
+      const leito = leitos.find(l => l.id === leitoId);
+      if (leito) {
+        registrarLog(
+          `Prioridade de higienização do leito ${leito.codigoLeito} ${!prioridadeAtual ? 'ativada' : 'desativada'}.`,
+          'Mapa de Leitos'
+        );
+      }
+    } catch (error) {
+      console.error('Erro ao alternar prioridade de higienização:', error);
+    }
+  };
+
   /**
    * Exclui um leito do sistema.
    */
@@ -270,5 +286,6 @@ export const useLeitos = () => {
     excluirLeito,
     atualizarStatusLeito,
     vincularPacienteLeito,
+    togglePrioridadeHigienizacao,
   };
 };

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -8,6 +8,13 @@ export interface AltaLeitoInfo {
   usuario: string; // Nome do usuário que registrou
 }
 
+export interface InfoAltaPendente {
+  tipo: 'medicacao' | 'transporte' | 'familiar' | 'emad' | 'outros';
+  detalhe?: string;
+  usuario: string;
+  timestamp: string;
+}
+
 export interface Paciente {
   id: string;
   leitoId: string;
@@ -29,6 +36,7 @@ export interface Paciente {
   dataPedidoRemanejamento?: string;
   provavelAlta?: boolean;
   altaNoLeito?: AltaLeitoInfo;
+  altaPendente?: InfoAltaPendente | null;
   origem?: {
     deSetor: string;
     deLeito: string;
@@ -53,7 +61,7 @@ export interface Leito {
   tipoLeito: string;
   leitoIsolamento: boolean;
   leitoPCP: boolean;
-  higienizacaoPrioritaria?: boolean; // Nova propriedade adicionada
+  prioridadeHigienizacao?: boolean;
   historicoMovimentacao: HistoricoLeito[];
 }
 


### PR DESCRIPTION
## Summary
- allow marking cleaning beds as priority with a siren icon
- support recording pending discharge details via modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint found errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adb0b7c23483229348e33a773d3180