### PR TITLE
feat: add pending discharge dashboard and fix time parsing

### DIFF
--- a/src/components/huddle/AltaNoLeito.tsx
+++ b/src/components/huddle/AltaNoLeito.tsx
@@ -1,0 +1,88 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { Badge } from '@/components/ui/badge';
+import { PlaneTakeoff } from 'lucide-react';
+import { Paciente, Leito, Setor } from '@/types/hospital';
+import { formatarDuracao } from '@/lib/utils';
+
+interface AltaNoLeitoProps {
+  altasPendentes: Record<string, Paciente[]>;
+  leitos: Leito[];
+  setores: Setor[];
+}
+
+const motivoLabels: Record<string, string> = {
+  medicacao: 'Finalizando Medicação',
+  transporte: 'Aguardando Transporte',
+  familiar: 'Aguardando Familiar',
+  emad: 'Aguardando EMAD',
+  outros: 'Outros',
+};
+
+export const AltaNoLeito = ({ altasPendentes, leitos, setores }: AltaNoLeitoProps) => {
+  const total = Object.values(altasPendentes).reduce((sum, arr) => sum + arr.length, 0);
+
+  const getSetorSigla = (setorId: string) => {
+    const setor = setores.find(s => s.id === setorId);
+    return setor ? setor.siglaSetor : 'Setor?';
+  };
+
+  const getLeitoCodigo = (leitoId: string) => {
+    const leito = leitos.find(l => l.id === leitoId);
+    return leito ? leito.codigoLeito : 'Leito?';
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <PlaneTakeoff className="h-5 w-5 text-blue-600" />
+          Radar de Altas Pendentes
+          <Badge variant="secondary">{total}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {total === 0 ? (
+          <p className="text-center text-muted-foreground py-4">
+            Nenhum paciente com alta pendente
+          </p>
+        ) : (
+          <Accordion type="multiple" className="w-full">
+            {Object.entries(altasPendentes).map(([tipo, pacientes]) => (
+              <AccordionItem key={tipo} value={tipo}>
+                <AccordionTrigger className="text-left">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{motivoLabels[tipo] || tipo}</span>
+                    <Badge variant="outline">{pacientes.length}</Badge>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <div className="space-y-3">
+                    {pacientes.map(paciente => (
+                      <div key={paciente.id} className="border rounded-lg p-4 bg-blue-50/50">
+                        <h4 className="font-medium">{paciente.nomeCompleto}</h4>
+                        <p className="text-sm text-muted-foreground">
+                          {getSetorSigla(paciente.setorId)} - {getLeitoCodigo(paciente.leitoId)}
+                        </p>
+                        {paciente.altaPendente?.timestamp && (
+                          <p className="text-xs text-muted-foreground">
+                            Espera: {formatarDuracao(paciente.altaPendente.timestamp)}
+                          </p>
+                        )}
+                        {paciente.altaPendente?.detalhe && (
+                          <p className="mt-1 text-sm font-medium">
+                            {paciente.altaPendente.detalhe}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/huddle/InternacaoProlongada.tsx
+++ b/src/components/huddle/InternacaoProlongada.tsx
@@ -5,10 +5,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Calendar, MessageSquare } from 'lucide-react';
-import { format, differenceInDays, parse, isValid } from 'date-fns';
+import { format, differenceInDays, isValid } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { ObservacoesAprimoradaModal } from '@/components/modals/ObservacoesAprimoradaModal';
 import { Paciente, Leito, Setor } from '@/types/hospital';
+import { parseDateFromString } from '@/lib/utils';
 
 interface Props {
   pacientes: Paciente[];
@@ -19,25 +20,12 @@ interface Props {
 }
 
 const parseDataInternacao = (dataStr: string): Date => {
-  // Primeiro tenta como ISO string (formato padrão)
-  let data = new Date(dataStr);
-  if (isValid(data)) {
-    return data;
-  }
+  const parsed = parseDateFromString(dataStr);
+  if (parsed) return parsed;
 
-  // Se não for válida, tenta como formato brasileiro DD/MM/YYYY
-  data = parse(dataStr, 'dd/MM/yyyy', new Date());
-  if (isValid(data)) {
-    return data;
-  }
+  const isoDate = new Date(dataStr);
+  if (isValid(isoDate)) return isoDate;
 
-  // Como último recurso, tenta DD/MM/YYYY HH:mm
-  data = parse(dataStr, 'dd/MM/yyyy HH:mm', new Date());
-  if (isValid(data)) {
-    return data;
-  }
-
-  // Se ainda não conseguir, retorna data atual como fallback
   console.warn('Data de internação inválida:', dataStr);
   return new Date();
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Converte uma string de data no formato 'dd/MM/yyyy HH:mm' para um objeto Date.
+ * Retorna null se a data for inválida.
+ * @param dateString A data em formato de string.
+ */
+export const parseDateFromString = (dateString: string): Date | null => {
+  if (!dateString) return null;
+
+  // O 'dd/MM/yyyy HH:mm' é o formato exato que vem do Firestore e da planilha.
+  const parsedDate = parse(dateString, 'dd/MM/yyyy HH:mm', new Date());
+
+  return isValid(parsedDate) ? parsedDate : null;
+};
+
 export const formatarDuracao = (dataISOouString: string | Date | undefined | null): string => {
   if (!dataISOouString) return 'N/A';
 

--- a/src/pages/Huddle.tsx
+++ b/src/pages/Huddle.tsx
@@ -6,6 +6,8 @@ import { PacientesComObservacoes } from '@/components/huddle/PacientesComObserva
 import { usePacientes } from '@/hooks/usePacientes';
 import { useLeitos } from '@/hooks/useLeitos';
 import { useSetores } from '@/hooks/useSetores';
+import { useHuddleList } from '@/hooks/useHuddleList';
+import { AltaNoLeito } from '@/components/huddle/AltaNoLeito';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditoria } from '@/hooks/useAuditoria';
 import { doc, updateDoc, arrayUnion, arrayRemove } from 'firebase/firestore';
@@ -18,6 +20,7 @@ const Huddle = () => {
   const { pacientes, loading: pacientesLoading } = usePacientes();
   const { leitos, loading: leitosLoading } = useLeitos();
   const { setores, loading: setoresLoading } = useSetores();
+  const { altasPendentes } = useHuddleList(pacientes);
   const { userData } = useAuth();
   const { registrarLog } = useAuditoria();
 
@@ -143,7 +146,7 @@ const Huddle = () => {
             onRemoverObservacao={handleRemoverObservacao}
           />
           
-          <InternacaoProlongada 
+          <InternacaoProlongada
             pacientes={pacientes}
             leitos={leitos}
             setores={setores}
@@ -151,7 +154,13 @@ const Huddle = () => {
             onRemoverObservacao={handleRemoverObservacao}
           />
 
-          <PacientesComObservacoes 
+          <AltaNoLeito
+            altasPendentes={altasPendentes}
+            leitos={leitos}
+            setores={setores}
+          />
+
+          <PacientesComObservacoes
             pacientes={pacientes}
             leitos={leitos}
             setores={setores}


### PR DESCRIPTION
## Summary
- add `parseDateFromString` to handle `dd/MM/yyyy HH:mm` strings
- group pending discharges and expose via `useHuddleList`
- show pending discharges in new `AltaNoLeito` component on Huddle page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: eslint: not found)
- `npm install` (fails: ERESOLVE could not resolve)


------
https://chatgpt.com/codex/tasks/task_e_68adc614835c8322b4eb16e3443c07d6