### PR TITLE
feat: add initial Kanban NIR

### DIFF
--- a/src/components/kanban/AdicionarPacienteModal.tsx
+++ b/src/components/kanban/AdicionarPacienteModal.tsx
@@ -1,0 +1,59 @@
+import { useState, useMemo } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Paciente } from '@/types/hospital';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pacientes: Paciente[];
+  existentes: string[]; // ids já presentes no Kanban
+  onSelect: (paciente: Paciente) => void;
+}
+
+export const AdicionarPacienteModal = ({ open, onOpenChange, pacientes, existentes, onSelect }: Props) => {
+  const [busca, setBusca] = useState('');
+
+  const resultados = useMemo(() => {
+    const termo = busca.toUpperCase();
+    return pacientes.filter(p =>
+      p.nomeCompleto.toUpperCase().includes(termo) && !existentes.includes(p.id)
+    );
+  }, [busca, pacientes, existentes]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Adicionar Paciente</DialogTitle>
+        </DialogHeader>
+        <Input
+          value={busca}
+          onChange={(e) => setBusca(e.target.value)}
+          placeholder="Buscar pelo nome"
+          className="mb-4"
+        />
+        <div className="max-h-64 overflow-auto space-y-2">
+          {resultados.map(p => (
+            <Button
+              key={p.id}
+              variant="ghost"
+              className="w-full justify-start"
+              onClick={() => {
+                onSelect(p);
+                setBusca('');
+                onOpenChange(false);
+              }}
+            >
+              {p.nomeCompleto}
+            </Button>
+          ))}
+          {resultados.length === 0 && (
+            <p className="text-sm text-muted-foreground">Nenhum paciente encontrado</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/kanban/KanbanModal.tsx
+++ b/src/components/kanban/KanbanModal.tsx
@@ -1,0 +1,214 @@
+import { useState, useMemo } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Plus, Calendar } from 'lucide-react';
+import { useKanban } from '@/hooks/useKanban';
+import { usePacientes } from '@/hooks/usePacientes';
+import { useLeitos } from '@/hooks/useLeitos';
+import { useSetores } from '@/hooks/useSetores';
+import { AdicionarPacienteModal } from './AdicionarPacienteModal';
+import { format, differenceInDays } from 'date-fns';
+import { KanbanEntry } from '@/types/kanban';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const PendenciasCell = ({ entry, onAdd }: { entry: KanbanEntry; onAdd: (id: string, texto: string) => void }) => {
+  const [open, setOpen] = useState(false);
+  const [texto, setTexto] = useState('');
+  return (
+    <div className="space-y-1">
+      {entry.pendencias.map(p => (
+        <div key={p.id} className="text-xs">
+          {p.texto} - {format(new Date(p.criadaEm), 'dd/MM')} ({p.criadaPor})
+        </div>
+      ))}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button size="sm" variant="ghost">
+            <Plus className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 space-y-2">
+          <Input
+            value={texto}
+            onChange={(e) => setTexto(e.target.value)}
+            placeholder="Nova pendência"
+          />
+          <Button
+            size="sm"
+            onClick={() => {
+              onAdd(entry.pacienteId, texto);
+              setTexto('');
+              setOpen(false);
+            }}
+            disabled={!texto}
+          >
+            Adicionar
+          </Button>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};
+
+const TratativasCell = ({ entry, onAdd }: { entry: KanbanEntry; onAdd: (id: string, texto: string) => void }) => {
+  const [open, setOpen] = useState(false);
+  const [texto, setTexto] = useState('');
+  return (
+    <div className="space-y-1">
+      {entry.tratativas.map(t => (
+        <div key={t.id} className="text-xs">
+          {t.texto} - {format(new Date(t.criadaEm), 'dd/MM')} ({t.criadaPor})
+        </div>
+      ))}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button size="sm" variant="ghost">
+            <Plus className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 space-y-2">
+          <Input
+            value={texto}
+            onChange={(e) => setTexto(e.target.value)}
+            placeholder="Nova tratativa"
+          />
+          <Button
+            size="sm"
+            onClick={() => {
+              onAdd(entry.pacienteId, texto);
+              setTexto('');
+              setOpen(false);
+            }}
+            disabled={!texto}
+          >
+            Adicionar
+          </Button>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};
+
+const PrevisaoAltaCell = ({ entry, onUpdate }: { entry: KanbanEntry; onUpdate: (id: string, data: string) => void }) => {
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState(entry.previsaoAlta || '');
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm">
+          <Calendar className="h-4 w-4 mr-1" />
+          {entry.previsaoAlta ? format(new Date(entry.previsaoAlta), 'dd/MM') : 'Definir'}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-48 space-y-2">
+        <Input type="date" value={data} onChange={(e) => setData(e.target.value)} />
+        <Button
+          size="sm"
+          onClick={() => {
+            onUpdate(entry.pacienteId, data);
+            setOpen(false);
+          }}
+          disabled={!data}
+        >
+          Salvar
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const KanbanModal = ({ open, onOpenChange }: Props) => {
+  const [adicionarOpen, setAdicionarOpen] = useState(false);
+  const [filtroNome, setFiltroNome] = useState('');
+  const { kanban, adicionarPendencia, adicionarTratativa, atualizarPrevisaoAlta, adicionarPacienteAoKanban } = useKanban();
+  const { pacientes } = usePacientes();
+  const { leitos } = useLeitos();
+  const { setores } = useSetores();
+
+  const dados = useMemo(() => {
+    return kanban
+      .map(entry => {
+        const paciente = pacientes.find(p => p.id === entry.pacienteId);
+        const leito = paciente ? leitos.find(l => l.id === paciente.leitoId) : undefined;
+        const setor = paciente ? setores.find(s => s.id === paciente.setorId) : undefined;
+        const tempoInternacao = paciente ? differenceInDays(new Date(), new Date(paciente.dataInternacao)) : null;
+        return { entry, paciente, leito, setor, tempoInternacao };
+      })
+      .filter(d => d.paciente && d.paciente.nomeCompleto.toUpperCase().includes(filtroNome.toUpperCase()));
+  }, [kanban, pacientes, leitos, setores, filtroNome]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-full h-full">
+        <DialogHeader className="flex flex-row items-center justify-between">
+          <DialogTitle>Kanban NIR</DialogTitle>
+          <Button onClick={() => setAdicionarOpen(true)}>Adicionar Paciente ao Monitoramento</Button>
+        </DialogHeader>
+
+        <div className="py-4">
+          <Input
+            placeholder="Filtrar por nome"
+            value={filtroNome}
+            onChange={(e) => setFiltroNome(e.target.value)}
+            className="max-w-sm mb-4"
+          />
+          <div className="overflow-auto max-h-[70vh]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Leito</TableHead>
+                  <TableHead>Setor</TableHead>
+                  <TableHead>Tempo Internação</TableHead>
+                  <TableHead>Previsão de Alta</TableHead>
+                  <TableHead>Pendências para Alta</TableHead>
+                  <TableHead>Tratativas</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {dados.map(({ entry, paciente, leito, setor, tempoInternacao }) => (
+                  <TableRow key={entry.id}>
+                    <TableCell>{paciente?.nomeCompleto || 'Paciente não encontrado'}</TableCell>
+                    <TableCell>{leito?.codigoLeito || ''}</TableCell>
+                    <TableCell>{setor?.siglaSetor || ''}</TableCell>
+                    <TableCell>{tempoInternacao !== null ? `${tempoInternacao}d` : '-'}</TableCell>
+                    <TableCell>
+                      <PrevisaoAltaCell entry={entry} onUpdate={atualizarPrevisaoAlta} />
+                    </TableCell>
+                    <TableCell>
+                      <PendenciasCell entry={entry} onAdd={adicionarPendencia} />
+                    </TableCell>
+                    <TableCell>
+                      <TratativasCell entry={entry} onAdd={adicionarTratativa} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {dados.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
+                      Nenhum paciente encontrado
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </DialogContent>
+      <AdicionarPacienteModal
+        open={adicionarOpen}
+        onOpenChange={setAdicionarOpen}
+        pacientes={pacientes}
+        existentes={kanban.map(k => k.pacienteId)}
+        onSelect={adicionarPacienteAoKanban}
+      />
+    </Dialog>
+  );
+};

--- a/src/hooks/useKanban.ts
+++ b/src/hooks/useKanban.ts
@@ -1,0 +1,118 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  collection,
+  onSnapshot,
+  doc,
+  setDoc,
+  updateDoc,
+  arrayUnion,
+  getDoc,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { KanbanEntry, KanbanPendencia, KanbanTratativa, PacienteKanban } from '@/types/kanban';
+import { useAuth } from './useAuth';
+
+export const useKanban = () => {
+  const [kanban, setKanban] = useState<KanbanEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { userData } = useAuth();
+
+  useEffect(() => {
+    const q = collection(db, 'kanbanRegulaFacil');
+    const unsub = onSnapshot(q, (snapshot) => {
+      const entries = snapshot.docs.map((d) => ({ id: d.id, ...d.data() })) as KanbanEntry[];
+      setKanban(entries);
+      setLoading(false);
+    });
+    return () => unsub();
+  }, []);
+
+  const adicionarPacienteAoKanban = useCallback(
+    async (paciente: PacienteKanban) => {
+      if (!userData) return;
+      const ref = doc(db, 'kanbanRegulaFacil', paciente.id);
+      const now = new Date().toISOString();
+      const data: KanbanEntry = {
+        id: paciente.id,
+        pacienteId: paciente.id,
+        monitoradoDesde: now,
+        monitoradoPor: userData.nomeCompleto,
+        ultimaAtualizacao: now,
+        pendencias: [],
+        tratativas: [],
+        finalizado: false,
+      };
+      await setDoc(ref, data);
+    },
+    [userData]
+  );
+
+  const adicionarPendencia = useCallback(
+    async (pacienteId: string, texto: string) => {
+      if (!userData) return;
+      const ref = doc(db, 'kanbanRegulaFacil', pacienteId);
+      const now = new Date().toISOString();
+      const pendencia: KanbanPendencia = {
+        id: crypto.randomUUID(),
+        texto,
+        criadaEm: now,
+        criadaPor: userData.nomeCompleto,
+        resolvida: false,
+      };
+      await updateDoc(ref, {
+        pendencias: arrayUnion(pendencia),
+        ultimaAtualizacao: now,
+      });
+    },
+    [userData]
+  );
+
+  const removerPendencia = useCallback(async (pacienteId: string, pendenciaId: string) => {
+    const ref = doc(db, 'kanbanRegulaFacil', pacienteId);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return;
+    const data = snap.data() as KanbanEntry;
+    const pendencias = data.pendencias.filter((p) => p.id !== pendenciaId);
+    await updateDoc(ref, {
+      pendencias,
+      ultimaAtualizacao: new Date().toISOString(),
+    });
+  }, []);
+
+  const adicionarTratativa = useCallback(
+    async (pacienteId: string, texto: string) => {
+      if (!userData) return;
+      const ref = doc(db, 'kanbanRegulaFacil', pacienteId);
+      const now = new Date().toISOString();
+      const tratativa: KanbanTratativa = {
+        id: crypto.randomUUID(),
+        texto,
+        criadaEm: now,
+        criadaPor: userData.nomeCompleto,
+      };
+      await updateDoc(ref, {
+        tratativas: arrayUnion(tratativa),
+        ultimaAtualizacao: now,
+      });
+    },
+    [userData]
+  );
+
+  const atualizarPrevisaoAlta = useCallback(async (pacienteId: string, data: string) => {
+    const ref = doc(db, 'kanbanRegulaFacil', pacienteId);
+    await updateDoc(ref, {
+      previsaoAlta: data,
+      ultimaAtualizacao: new Date().toISOString(),
+    });
+  }, []);
+
+  return {
+    kanban,
+    loading,
+    adicionarPacienteAoKanban,
+    adicionarPendencia,
+    removerPendencia,
+    adicionarTratativa,
+    atualizarPrevisaoAlta,
+  };
+};

--- a/src/pages/Huddle.tsx
+++ b/src/pages/Huddle.tsx
@@ -12,8 +12,11 @@ import { Accordion } from '@/components/ui/accordion';
 import { doc, updateDoc, arrayUnion, arrayRemove } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { toast } from '@/hooks/use-toast';
-import { Users } from 'lucide-react';
+import { Users, KanbanSquare } from 'lucide-react';
 import { Observacao } from '@/types/observacao';
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+import { KanbanModal } from '@/components/kanban/KanbanModal';
 
 const Huddle = () => {
   const { pacientes, loading: pacientesLoading } = usePacientes();
@@ -21,6 +24,7 @@ const Huddle = () => {
   const { setores, loading: setoresLoading } = useSetores();
   const { userData } = useAuth();
   const { registrarLog } = useAuditoria();
+  const [kanbanOpen, setKanbanOpen] = useState(false);
 
   const loading = pacientesLoading || leitosLoading || setoresLoading;
 
@@ -116,18 +120,24 @@ const Huddle = () => {
   return (
     <div className="min-h-screen bg-gradient-subtle">
       <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center gap-4 mb-8">
-          <div className="w-12 h-12 rounded-lg bg-medical-primary flex items-center justify-center">
-            <Users className="h-6 w-6 text-white" />
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-4">
+            <div className="w-12 h-12 rounded-lg bg-medical-primary flex items-center justify-center">
+              <Users className="h-6 w-6 text-white" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-medical-primary">
+                Huddle - Panorama de Pacientes
+              </h1>
+              <p className="text-muted-foreground">
+                Acompanhamento de pacientes com necessidades específicas
+              </p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-3xl font-bold text-medical-primary">
-              Huddle - Panorama de Pacientes
-            </h1>
-            <p className="text-muted-foreground">
-              Acompanhamento de pacientes com necessidades específicas
-            </p>
-          </div>
+          <Button onClick={() => setKanbanOpen(true)}>
+            <KanbanSquare className="h-4 w-4 mr-2" />
+            KANBAN NIR
+          </Button>
         </div>
 
         <Accordion type="multiple" className="space-y-4">
@@ -156,6 +166,7 @@ const Huddle = () => {
           />
         </Accordion>
       </div>
+      <KanbanModal open={kanbanOpen} onOpenChange={setKanbanOpen} />
     </div>
   );
 };

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -1,0 +1,38 @@
+import { Paciente } from './hospital';
+
+// Representa uma pendência para a alta do paciente
+export interface KanbanPendencia {
+  id: string; // UUID para identificação única
+  texto: string;
+  criadaEm: string; // ISO Timestamp
+  criadaPor: string; // Nome do usuário
+  resolvida: boolean;
+  resolvidaEm?: string;
+  resolvidaPor?: string;
+}
+
+// Representa uma nota ou encaminhamento sobre o paciente
+export interface KanbanTratativa {
+  id: string; // UUID
+  texto: string;
+  criadaEm: string; // ISO Timestamp
+  criadaPor: string;
+}
+
+// O documento principal na coleção kanbanRegulaFacil
+export interface KanbanEntry {
+  id: string; // Cópia do pacienteId
+  pacienteId: string;
+  monitoradoDesde: string;
+  monitoradoPor: string;
+  ultimaAtualizacao: string;
+  previsaoAlta?: string; // Data no formato 'AAAA-MM-DD'
+  pendencias: KanbanPendencia[];
+  tratativas: KanbanTratativa[];
+  finalizado: boolean; // Para "arquivar" o monitoramento
+  finalizadoEm?: string;
+  finalizadoPor?: string;
+}
+
+// Tipo auxiliar utilizado ao adicionar pacientes
+export type PacienteKanban = Paciente;


### PR DESCRIPTION
## Summary
- model kanban data types and hook for Firestore
- add Kanban modal with patient monitoring table and popovers
- wire kanban access button into Huddle page

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68addbaca04883228f7fc7ec482d2ea4