### PR TITLE
fix: align hospital types

### DIFF
--- a/src/hooks/useRegulacaoLogic.ts
+++ b/src/hooks/useRegulacaoLogic.ts
@@ -593,12 +593,12 @@ const registrarHistoricoRegulacao = async (
       };
 
       // 4. VERIFICA E FINALIZA O PEDIDO DE UTI (se aplicável)
-      if (pacienteCompleto.aguardaUTI && setorDestino.tipoUnidade?.toUpperCase() === 'UTI') {
+      if (pacienteCompleto.aguardaUTI && leitoDestino.tipoLeito?.toUpperCase() === 'UTI') {
           const dataPedido = new Date(pacienteCompleto.dataPedidoUTI);
           const dataConclusao = new Date();
           const duracao = intervalToDuration({ start: dataPedido, end: dataConclusao });
           const tempoDeEspera = `${duracao.days || 0}d ${duracao.hours || 0}h ${duracao.minutes || 0}m`;
-          
+
           const logUTI = `Pedido de UTI para ${pacienteCompleto.nomeCompleto} finalizado após ${tempoDeEspera}. Paciente alocado no leito ${leitoDestino.codigoLeito}. Conclusão em: ${dataConclusao.toLocaleString('pt-BR')}.`;
           registrarLog(logUTI, "Fila de UTI");
 

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -46,6 +46,12 @@ export interface Paciente {
   obsAltaProvavel?: Observacao[];
   obsInternacaoProlongada?: Observacao[];
   setorOrigem?: string;
+  idade?: number | string;
+  prioridade?: number;
+  solicitadoPor?: string;
+  leitoNecessario?: 'Enfermaria' | 'UTI';
+  condicaoClinica?: string;
+  dataSolicitacao?: string;
 }
 
 export interface IsolamentoVigente {
@@ -149,6 +155,7 @@ export interface Regulacao {
   setorDestinoNome: string;
   historicoEventos: Array<{ evento: string; timestamp: string }>;
   justificativaHomonimo?: string;
+  pacienteId: string;
 }
 
 // Alias for backward compatibility


### PR DESCRIPTION
## Summary
- extend Paciente and Regulacao interfaces with current fields
- rely on leito type to finalize UTI requests

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0744ab6188322aff6b6782cef5365