### PR TITLE
feat: add session timeout handler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import MaintenancePage from '@/pages/MaintenancePage';
 import NotFound from '@/pages/NotFound';
 import ProtectedLayout from '@/components/ProtectedLayout';
 import { AuthProvider } from '@/hooks/useAuth';
+import { SessionTimeoutProvider } from '@/hooks/useSessionTimeout';
 import { useSistemaConfig } from '@/hooks/useSistemaConfig';
 
 const queryClient = new QueryClient();
@@ -73,9 +74,11 @@ function App() {
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <TooltipProvider>
-            <AppContent />
-          </TooltipProvider>
+          <SessionTimeoutProvider>
+            <TooltipProvider>
+              <AppContent />
+            </TooltipProvider>
+          </SessionTimeoutProvider>
         </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>

--- a/src/hooks/useSessionTimeout.tsx
+++ b/src/hooks/useSessionTimeout.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useContext, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from './useAuth';
+import { useToast } from './use-toast';
+
+type SessionTimeoutContextValue = Record<string, never>;
+
+const SessionTimeoutContext = createContext<SessionTimeoutContextValue>({});
+
+const TIMEOUT_DURATION = 120 * 60 * 1000;
+
+export const SessionTimeoutProvider = ({ children }: { children: React.ReactNode }) => {
+  const { currentUser, logout } = useAuth();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleLogout = useCallback(() => {
+    logout();
+    toast({
+      title: 'Sessão Encerrada',
+      description: 'Sua sessão foi encerrada por inatividade.',
+      variant: 'default',
+    });
+    navigate('/login');
+  }, [logout, toast, navigate]);
+
+  const resetTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(handleLogout, TIMEOUT_DURATION);
+  }, [handleLogout]);
+
+  useEffect(() => {
+    if (currentUser) {
+      const events = ['mousemove', 'mousedown', 'keypress', 'scroll', 'touchstart'];
+
+      const eventListener = () => {
+        resetTimer();
+      };
+
+      events.forEach((event) => {
+        window.addEventListener(event, eventListener);
+      });
+
+      resetTimer();
+
+      return () => {
+        events.forEach((event) => {
+          window.removeEventListener(event, eventListener);
+        });
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+        }
+      };
+    }
+  }, [currentUser, resetTimer]);
+
+  return (
+    <SessionTimeoutContext.Provider value={{}}>
+      {children}
+    </SessionTimeoutContext.Provider>
+  );
+};
+
+export const useSessionTimeout = () => useContext(SessionTimeoutContext);
+


### PR DESCRIPTION
## Summary
- add session timeout context that logs out inactive users after two hours
- wrap app with session timeout provider

## Testing
- `npm run lint` *(fails: Unexpected any... A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b078ab57548322add3cbe3cae1f281