### PR TITLE
refactor: enhance remanejamento workflow

### DIFF
--- a/src/components/RemanejamentoPendenteItem.tsx
+++ b/src/components/RemanejamentoPendenteItem.tsx
@@ -4,52 +4,70 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { ArrowRightLeft, Clock, XCircle } from 'lucide-react';
-import { formatarDuracao } from '@/lib/utils';
+import { formatarDuracao, descreverMotivoRemanejamento } from '@/lib/utils';
+import type { Paciente } from '@/types/hospital';
 
 interface Props {
-  paciente: any;
-  onRemanejar: (paciente: any) => void;
-  onCancelar: (paciente: any) => void;
+  paciente: Paciente;
+  onRemanejar: (paciente: Paciente) => void;
+  onCancelar: (paciente: Paciente) => void;
 }
 
 export const RemanejamentoPendenteItem = ({ paciente, onRemanejar, onCancelar }: Props) => {
-    // 1. Calcula o tempo de espera usando a função utilitária.
-    const tempoAguardando = formatarDuracao(paciente.dataPedidoRemanejamento);
-    
-    return (
-        <div className="flex items-center justify-between p-3 rounded-lg hover:bg-muted/50">
-            <div>
-                {/* 2. Exibe as informações do paciente. */}
-                <p className="font-bold text-sm">{paciente.nomeCompleto} <Badge variant="outline">{paciente.sexoPaciente.charAt(0)}</Badge></p>
-                <p className="text-xs text-muted-foreground">{paciente.siglaSetorOrigem || paciente.setorOrigem} - {paciente.leitoCodigo}</p>
-                <p className="text-xs text-amber-600 mt-1">Motivo: {paciente.motivoRemanejamento}</p>
-            </div>
-            <div className="flex items-center gap-2">
-                <div className="flex items-center gap-1 text-xs font-mono text-amber-600">
-                    <Clock className="h-3 w-3"/>
-                    {tempoAguardando}
-                </div>
-                <TooltipProvider>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            {/* 3. Botão de Remanejar: Ao ser clicado, chama a função `onRemanejar` que veio da página principal. */}
-                            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onRemanejar(paciente)}>
-                                <ArrowRightLeft className="h-4 w-4"/>
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent><p>Remanejar Paciente</p></TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            {/* 4. Botão de Cancelar: Ao ser clicado, chama a função `onCancelar` que veio da página principal. */}
-                            <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive" onClick={() => onCancelar(paciente)}>
-                                <XCircle className="h-4 w-4"/>
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent><p>Cancelar Solicitação</p></TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
-            </div>
+  const tempoAguardando = formatarDuracao(paciente.dataPedidoRemanejamento);
+
+  return (
+    <div className="flex items-center justify-between p-3 rounded-lg hover:bg-muted/50">
+      <div>
+        <p className="font-bold text-sm">
+          {paciente.nomeCompleto}{' '}
+          <Badge variant="outline">{paciente.sexoPaciente.charAt(0)}</Badge>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {paciente.siglaSetorOrigem || paciente.setorOrigem} - {paciente.leitoCodigo}
+        </p>
+        <p className="text-xs text-amber-600 mt-1">
+          {descreverMotivoRemanejamento(paciente.motivoRemanejamento)}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 text-xs font-mono text-amber-600">
+          <Clock className="h-3 w-3" />
+          {tempoAguardando}
         </div>
-    );
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => onRemanejar(paciente)}
+              >
+                <ArrowRightLeft className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remanejar Paciente</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive"
+                onClick={() => onCancelar(paciente)}
+              >
+                <XCircle className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Cancelar Solicitação</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
 };

--- a/src/components/RemanejamentosPendentesBloco.tsx
+++ b/src/components/RemanejamentosPendentesBloco.tsx
@@ -2,9 +2,11 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { ChevronDown } from "lucide-react";
 import { useState } from "react";
 import { RemanejamentoPendenteItem } from "@/components/RemanejamentoPendenteItem";
+import type { TipoRemanejamento } from "@/types/hospital";
 
 interface RemanejamentosPendentesBlocoProps {
   pacientesAguardandoRemanejamento: any[];
@@ -12,16 +14,40 @@ interface RemanejamentosPendentesBlocoProps {
   onCancelar: (paciente: any) => void;
 }
 
-export const RemanejamentosPendentesBloco = ({ 
-  pacientesAguardandoRemanejamento, 
-  onRemanejar, 
-  onCancelar 
+export const RemanejamentosPendentesBloco = ({
+  pacientesAguardandoRemanejamento,
+  onRemanejar,
+  onCancelar,
 }: RemanejamentosPendentesBlocoProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  if (pacientesAguardandoRemanejamento.length === 0) {
+  const pacientesFiltrados = pacientesAguardandoRemanejamento.filter(
+    (p) => p.remanejarPaciente
+  );
+
+  if (pacientesFiltrados.length === 0) {
     return null;
   }
+
+  const grupos = pacientesFiltrados.reduce(
+    (acc: Record<TipoRemanejamento, any[]>, paciente) => {
+      let tipo: TipoRemanejamento = 'incompatibilidade_biologica';
+      if (typeof paciente.motivoRemanejamento === 'object' && paciente.motivoRemanejamento)
+        tipo = paciente.motivoRemanejamento.tipo;
+      acc[tipo] = acc[tipo] || [];
+      acc[tipo].push(paciente);
+      return acc;
+    },
+    {} as Record<TipoRemanejamento, any[]>
+  );
+
+  const labels: Record<TipoRemanejamento, string> = {
+    priorizacao: 'Pedido de Priorização',
+    adequacao_perfil: 'Adequação de Perfil Clínico',
+    melhoria_assistencia: 'Melhoria na Assistência',
+    liberado_isolamento: 'Liberado de Isolamento',
+    incompatibilidade_biologica: 'Incompatibilidade Biológica',
+  };
 
   return (
     <Card className="shadow-card border border-border/50">
@@ -31,24 +57,42 @@ export const RemanejamentosPendentesBloco = ({
             <CardTitle className="text-xl font-semibold text-medical-primary flex items-center justify-between">
               <div className="flex items-center gap-2">
                 Remanejamentos Pendentes
-                <Badge variant="destructive">{pacientesAguardandoRemanejamento.length}</Badge>
+                <Badge variant="destructive">{pacientesFiltrados.length}</Badge>
               </div>
-              <ChevronDown className={`h-4 w-4 shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
+              <ChevronDown
+                className={`h-4 w-4 shrink-0 transition-transform duration-200 ${
+                  isOpen ? 'rotate-180' : ''
+                }`}
+              />
             </CardTitle>
           </CardHeader>
         </CollapsibleTrigger>
         <CollapsibleContent>
           <CardContent>
-            <div className="space-y-2">
-              {pacientesAguardandoRemanejamento.map((paciente) => (
-                <RemanejamentoPendenteItem
-                  key={paciente.id}
-                  paciente={paciente}
-                  onRemanejar={() => onRemanejar(paciente)}
-                  onCancelar={() => onCancelar(paciente)}
-                />
+            <Accordion type="multiple" className="w-full">
+              {Object.entries(grupos).map(([tipo, pacientes]) => (
+                <AccordionItem key={tipo} value={tipo} className="border rounded-lg">
+                  <AccordionTrigger className="px-4 hover:no-underline">
+                    <div className="flex items-center gap-2">
+                      {labels[tipo as TipoRemanejamento]}
+                      <Badge variant="destructive">{pacientes.length}</Badge>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="space-y-2">
+                      {pacientes.map((paciente: any) => (
+                        <RemanejamentoPendenteItem
+                          key={paciente.id}
+                          paciente={paciente}
+                          onRemanejar={() => onRemanejar(paciente)}
+                          onCancelar={() => onCancelar(paciente)}
+                        />
+                      ))}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
               ))}
-            </div>
+            </Accordion>
           </CardContent>
         </CollapsibleContent>
       </Collapsible>

--- a/src/components/modals/RegulacaoModal.tsx
+++ b/src/components/modals/RegulacaoModal.tsx
@@ -19,6 +19,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { descreverMotivoRemanejamento } from '@/lib/utils';
 
 interface RegulacaoModalProps {
   open: boolean;
@@ -115,7 +116,7 @@ const getMensagemConfirmacao = () => {
 Paciente: ${paciente.nomeCompleto} - ${paciente.sexoPaciente} - ${idade} anos
 Origem: ${origem.setor} - ${origem.leito}
 Destino: ${leitoSelecionado.setorNome} - ${leitoSelecionado.codigoLeito}
-Motivo do Remanejamento: ${paciente.motivoRemanejamento}
+Motivo do Remanejamento: ${descreverMotivoRemanejamento(paciente.motivoRemanejamento)}
 Isolamento: ${isolamentos}${obs}`;
 
         // Define as orientações com base na comparação dos setores.

--- a/src/components/modals/RemanejamentoModal.tsx
+++ b/src/components/modals/RemanejamentoModal.tsx
@@ -1,45 +1,179 @@
-
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSetores } from '@/hooks/useSetores';
+import type { DetalhesRemanejamento, TipoRemanejamento } from '@/types/hospital';
 
 interface RemanejamentoModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (motivo: string) => void;
+  onConfirm: (detalhes: DetalhesRemanejamento) => void;
 }
 
+const options: { value: TipoRemanejamento; label: string }[] = [
+  { value: 'priorizacao', label: 'Pedido de Priorização' },
+  { value: 'adequacao_perfil', label: 'Adequação de Perfil Clínico' },
+  { value: 'melhoria_assistencia', label: 'Melhoria na Assistência' },
+  { value: 'liberado_isolamento', label: 'Liberado de Isolamento' },
+];
+
 export const RemanejamentoModal = ({ open, onOpenChange, onConfirm }: RemanejamentoModalProps) => {
-  const [motivo, setMotivo] = useState('');
-  
+  const [tipo, setTipo] = useState<TipoRemanejamento>('priorizacao');
+  const [justificativa, setJustificativa] = useState('');
+  const [setoresSelecionados, setSetoresSelecionados] = useState<string[]>([]);
+  const { setores } = useSetores();
+
+  const toggleSetor = (id: string) => {
+    setSetoresSelecionados((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
+    );
+  };
+
+  const isValid = () => {
+    switch (tipo) {
+      case 'priorizacao':
+      case 'melhoria_assistencia':
+        return justificativa.trim().length > 0;
+      case 'adequacao_perfil':
+        return setoresSelecionados.length > 0;
+      default:
+        return true;
+    }
+  };
+
+  const handleConfirm = () => {
+    const detalhes: DetalhesRemanejamento = { tipo };
+    if (tipo === 'priorizacao' || tipo === 'melhoria_assistencia') {
+      detalhes.justificativa = justificativa;
+    }
+    if (tipo === 'adequacao_perfil') {
+      detalhes.setoresSugeridos = setoresSelecionados;
+    }
+    onConfirm(detalhes);
+    onOpenChange(false);
+    setTipo('priorizacao');
+    setJustificativa('');
+    setSetoresSelecionados([]);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Solicitar Remanejamento</DialogTitle>
-          <DialogDescription>Descreva o motivo da solicitação de remanejamento do paciente.</DialogDescription>
+          <DialogDescription>
+            Selecione o motivo e preencha as informações necessárias.
+          </DialogDescription>
         </DialogHeader>
-        <div className="py-4">
-          <Label htmlFor="motivo-remanejamento">Motivo</Label>
-          <Textarea 
-            id="motivo-remanejamento" 
-            value={motivo} 
-            onChange={(e) => setMotivo(e.target.value)} 
-            placeholder="Ex: Paciente necessita de isolamento de contato..." 
-          />
+        <div className="space-y-4 py-4">
+          <RadioGroup value={tipo} onValueChange={(v) => setTipo(v as TipoRemanejamento)}>
+            {options.map((opt) => (
+              <div key={opt.value} className="flex items-center space-x-2">
+                <RadioGroupItem value={opt.value} id={opt.value} />
+                <Label htmlFor={opt.value}>{opt.label}</Label>
+              </div>
+            ))}
+          </RadioGroup>
+
+          {tipo === 'priorizacao' && (
+            <div className="space-y-2">
+              <Label htmlFor="just-priorizacao">Quem solicitou e o motivo</Label>
+              <Textarea
+                id="just-priorizacao"
+                value={justificativa}
+                onChange={(e) => setJustificativa(e.target.value)}
+              />
+            </div>
+          )}
+
+          {tipo === 'melhoria_assistencia' && (
+            <div className="space-y-2">
+              <Label htmlFor="just-melhoria">Justificativa clínica</Label>
+              <Textarea
+                id="just-melhoria"
+                value={justificativa}
+                onChange={(e) => setJustificativa(e.target.value)}
+              />
+            </div>
+          )}
+
+          {tipo === 'adequacao_perfil' && (
+            <div className="space-y-2">
+              <Label>Setor(es) sugerido(s)</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start font-normal"
+                  >
+                    {setoresSelecionados.length > 0
+                      ? `${setoresSelecionados.length} selecionado(s)`
+                      : 'Selecione o(s) setor(es)'}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                  <Command>
+                    <CommandInput placeholder="Buscar setor..." />
+                    <CommandList>
+                      <CommandEmpty>Nenhum setor encontrado.</CommandEmpty>
+                      <CommandGroup>
+                        {setores.map((setor) => (
+                          <CommandItem
+                            key={setor.id}
+                            value={setor.nomeSetor}
+                            onSelect={() => toggleSetor(setor.id)}
+                          >
+                            <div
+                              className={cn(
+                                'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                                setoresSelecionados.includes(setor.id)
+                                  ? 'bg-primary text-primary-foreground'
+                                  : 'opacity-50 [&_svg]:invisible'
+                              )}
+                            >
+                              <Check className="h-4 w-4" />
+                            </div>
+                            {setor.nomeSetor}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+          )}
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancelar</Button>
-          <Button 
-            onClick={() => { 
-              onConfirm(motivo); 
-              onOpenChange(false); 
-              setMotivo('');
-            }} 
-            disabled={!motivo.trim()}
-          >
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirm} disabled={!isValid()}>
             Confirmar
           </Button>
         </DialogFooter>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,3 +56,32 @@ export const formatarDuracao = (dataISOouString: string | Date | undefined | nul
     return 'Erro';
   }
 };
+
+import type { DetalhesRemanejamento } from '@/types/hospital';
+
+export const descreverMotivoRemanejamento = (
+  detalhes?: DetalhesRemanejamento | string | null
+): string => {
+  if (!detalhes) return '';
+  if (typeof detalhes === 'string') return detalhes;
+  switch (detalhes.tipo) {
+    case 'priorizacao':
+      return detalhes.justificativa
+        ? `Pedido de Priorização: ${detalhes.justificativa}`
+        : 'Pedido de Priorização';
+    case 'adequacao_perfil':
+      return detalhes.setoresSugeridos?.length
+        ? `Adequação de Perfil Clínico: ${detalhes.setoresSugeridos.join(', ')}`
+        : 'Adequação de Perfil Clínico';
+    case 'melhoria_assistencia':
+      return detalhes.justificativa
+        ? `Melhoria na Assistência: ${detalhes.justificativa}`
+        : 'Melhoria na Assistência';
+    case 'liberado_isolamento':
+      return 'Liberado de Isolamento';
+    case 'incompatibilidade_biologica':
+      return 'Incompatibilidade Biológica';
+    default:
+      return '';
+  }
+};

--- a/src/pages/MapaLeitos.tsx
+++ b/src/pages/MapaLeitos.tsx
@@ -26,7 +26,7 @@ import { RelatorioIsolamentosModal } from '@/components/modals/RelatorioIsolamen
 import { RelatorioVagosModal } from '@/components/modals/RelatorioVagosModal';
 import { RelatorioEspecialidadeModal } from '@/components/modals/RelatorioEspecialidadeModal';
 import { ObservacoesModal } from '@/components/modals/ObservacoesModal';
-import { Leito, Paciente, HistoricoMovimentacao, AltaLeitoInfo, LeitoEnriquecido, InfoAltaPendente } from '@/types/hospital';
+import { Leito, Paciente, HistoricoMovimentacao, AltaLeitoInfo, LeitoEnriquecido, InfoAltaPendente, DetalhesRemanejamento } from '@/types/hospital';
 import { doc, updateDoc, arrayUnion, deleteDoc, arrayRemove, writeBatch } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useToast } from '@/hooks/use-toast';
@@ -279,10 +279,10 @@ const MapaLeitos = () => {
       toast({ title: "Sucesso!", description: "Pedido de UTI solicitado." });
     },
 
-    onSolicitarRemanejamento: async (pacienteId: string, motivo: string) => {
+    onSolicitarRemanejamento: async (pacienteId: string, motivo: DetalhesRemanejamento) => {
       const pacienteRef = doc(db, 'pacientesRegulaFacil', pacienteId);
-      await updateDoc(pacienteRef, { 
-        remanejarPaciente: true, 
+      await updateDoc(pacienteRef, {
+        remanejarPaciente: true,
         motivoRemanejamento: motivo,
         dataPedidoRemanejamento: new Date().toISOString()
       });

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -1,6 +1,19 @@
 
 import { Observacao } from './observacao';
 
+export type TipoRemanejamento =
+  | 'priorizacao'
+  | 'adequacao_perfil'
+  | 'melhoria_assistencia'
+  | 'liberado_isolamento'
+  | 'incompatibilidade_biologica';
+
+export interface DetalhesRemanejamento {
+  tipo: TipoRemanejamento;
+  justificativa?: string;
+  setoresSugeridos?: string[];
+}
+
 export interface AltaLeitoInfo {
   status: boolean;
   pendencia: string;
@@ -32,7 +45,7 @@ export interface Paciente {
   motivoTransferencia?: string;
   dataTransferencia?: string;
   remanejarPaciente?: boolean;
-  motivoRemanejamento?: string;
+  motivoRemanejamento?: DetalhesRemanejamento | string | null;
   dataPedidoRemanejamento?: string;
   provavelAlta?: boolean;
   altaNoLeito?: AltaLeitoInfo;


### PR DESCRIPTION
## Summary
- structure remanejamento data with typed details and categories
- rebuild remanejamento modal with radio-driven form and sector multiselect
- group pending remanejamento requests by category via accordion view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 886 problems, mostly unexpected any types)*

------
https://chatgpt.com/codex/tasks/task_e_68b086d130308322bff01c92e2b0641f