### PR TITLE
feat: oncologia bed reservation flow

### DIFF
--- a/src/components/AcoesRapidas.tsx
+++ b/src/components/AcoesRapidas.tsx
@@ -6,7 +6,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { Download, ClipboardPaste, Lightbulb, BarChart3, Stethoscope, Newspaper } from 'lucide-react';
+import { Download, ClipboardPaste, Lightbulb, BarChart3, Stethoscope, Newspaper, ClipboardPlus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface AcoesRapidasProps {
@@ -16,6 +16,7 @@ interface AcoesRapidasProps {
   onSugestoesClick?: () => void;
   onPanoramaClick?: () => void;
   onRelatorioEspecialidadeClick?: () => void;
+  onReservaOncologiaClick?: () => void;
   showAllButtons?: boolean;
   sugestoesDisponiveis?: boolean;
   panoramaDisponivel?: boolean;
@@ -28,6 +29,7 @@ export const AcoesRapidas = ({
   onSugestoesClick,
   onPanoramaClick,
   onRelatorioEspecialidadeClick,
+  onReservaOncologiaClick,
   showAllButtons = false,
   sugestoesDisponiveis = false,
   panoramaDisponivel = false
@@ -82,6 +84,23 @@ export const AcoesRapidas = ({
             </TooltipTrigger>
             <TooltipContent>
               <p>Ocupação por Especialidade</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+
+        {onReservaOncologiaClick && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={onReservaOncologiaClick}
+              >
+                <ClipboardPlus className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Reservas Oncologia</p>
             </TooltipContent>
           </Tooltip>
         )}

--- a/src/components/modals/AdicionarEditarReservaModal.tsx
+++ b/src/components/modals/AdicionarEditarReservaModal.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { ReservaOncologia } from '@/types/reservaOncologia';
+
+const schema = z.object({
+  nomeCompleto: z.string().min(1, 'Nome é obrigatório'),
+  dataNascimento: z.string().min(1, 'Data de nascimento é obrigatória'),
+  sexo: z.enum(['Masculino', 'Feminino']),
+  telefone: z.string().min(1, 'Telefone é obrigatório'),
+  dataPrevistaInternacao: z.string().min(1, 'Data prevista é obrigatória'),
+  especialidade: z.enum(['HEMATOLOGIA', 'ONCOLOGIA']),
+});
+
+export type ReservaFormData = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: ReservaFormData) => void;
+  reserva?: ReservaOncologia | null;
+}
+
+export const AdicionarEditarReservaModal = ({ open, onOpenChange, onSubmit, reserva }: Props) => {
+  const form = useForm<ReservaFormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      nomeCompleto: '',
+      dataNascimento: '',
+      sexo: 'Masculino',
+      telefone: '',
+      dataPrevistaInternacao: '',
+      especialidade: 'ONCOLOGIA',
+    },
+  });
+
+  useEffect(() => {
+    if (reserva) {
+      form.reset({
+        nomeCompleto: reserva.nomeCompleto,
+        dataNascimento: reserva.dataNascimento,
+        sexo: reserva.sexo,
+        telefone: reserva.telefone,
+        dataPrevistaInternacao: reserva.dataPrevistaInternacao,
+        especialidade: reserva.especialidade,
+      });
+    } else {
+      form.reset({
+        nomeCompleto: '',
+        dataNascimento: '',
+        sexo: 'Masculino',
+        telefone: '',
+        dataPrevistaInternacao: '',
+        especialidade: 'ONCOLOGIA',
+      });
+    }
+  }, [reserva, form]);
+
+  const handleSubmit = (data: ReservaFormData) => {
+    onSubmit(data);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{reserva ? 'Editar' : 'Adicionar'} Reserva</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="nomeCompleto"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nome Completo</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="dataNascimento"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Data de Nascimento</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="sexo"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Sexo</FormLabel>
+                  <FormControl>
+                    <RadioGroup onValueChange={field.onChange} value={field.value} className="flex space-x-4">
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="Masculino" id="masc" />
+                        <Label htmlFor="masc">Masculino</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="Feminino" id="fem" />
+                        <Label htmlFor="fem">Feminino</Label>
+                      </div>
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="telefone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Telefone</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="dataPrevistaInternacao"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Data Prevista Internação</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="especialidade"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Especialidade</FormLabel>
+                  <FormControl>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="HEMATOLOGIA">HEMATOLOGIA</SelectItem>
+                        <SelectItem value="ONCOLOGIA">ONCOLOGIA</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit">Salvar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/modals/ContatoReservaModal.tsx
+++ b/src/components/modals/ContatoReservaModal.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { ReservaOncologia, TentativaContato } from '@/types/reservaOncologia';
+import { LeitoEnriquecido } from '@/types/hospital';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  paciente: ReservaOncologia | null;
+  leitos: LeitoEnriquecido[];
+  registrarTentativa: (id: string, tentativa: TentativaContato) => Promise<void>;
+  onConfirmarReserva: (paciente: ReservaOncologia, leito: LeitoEnriquecido) => Promise<void>;
+  onMarcarInternado: (id: string) => Promise<void>;
+}
+
+const motivosFalha = [
+  'CAIXA POSTAL',
+  'NÃO RESPONDEU',
+  'SINTOMAS RESPIRATÓRIOS',
+  'RECUSA PARA INTERNAÇÃO',
+  'ÓBITO',
+  'SEM MEDICAÇÃO',
+  'JÁ INTERNADO',
+] as const;
+
+export const ContatoReservaModal = ({
+  open,
+  onOpenChange,
+  paciente,
+  leitos,
+  registrarTentativa,
+  onConfirmarReserva,
+  onMarcarInternado,
+}: Props) => {
+  const [contatoSucesso, setContatoSucesso] = useState<boolean | null>(null);
+  const [motivo, setMotivo] = useState<typeof motivosFalha[number] | ''>('');
+  const [leitoSelecionado, setLeitoSelecionado] = useState<string>('');
+
+  const reset = () => {
+    setContatoSucesso(null);
+    setMotivo('');
+    setLeitoSelecionado('');
+  };
+
+  const fechar = () => {
+    reset();
+    onOpenChange(false);
+  };
+
+  const handleConfirm = async () => {
+    if (!paciente) return;
+    const agora = new Date().toISOString();
+
+    if (contatoSucesso === false) {
+      await registrarTentativa(paciente.id, { data: agora, sucesso: false, motivoFalha: motivo });
+      fechar();
+      return;
+    }
+
+    const leito = leitos.find(l => l.id === leitoSelecionado);
+    if (!leito) return;
+
+    await registrarTentativa(paciente.id, { data: agora, sucesso: true });
+    await onConfirmarReserva(paciente, leito);
+    await onMarcarInternado(paciente.id);
+    fechar();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={fechar}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Contato - {paciente?.nomeCompleto}</DialogTitle>
+        </DialogHeader>
+        {contatoSucesso === null && (
+          <div className="space-y-4 py-4">
+            <p className="text-sm">Contato com sucesso?</p>
+            <div className="flex justify-between">
+              <Button onClick={() => setContatoSucesso(true)}>Sim</Button>
+              <Button variant="destructive" onClick={() => setContatoSucesso(false)}>
+                Não
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {contatoSucesso === false && (
+          <div className="space-y-4 py-4">
+            <Select value={motivo} onValueChange={(v) => setMotivo(v as any)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione o motivo" />
+              </SelectTrigger>
+              <SelectContent>
+                {motivosFalha.map((m) => (
+                  <SelectItem key={m} value={m}>
+                    {m}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {contatoSucesso === true && (
+          <div className="space-y-4 py-4">
+            <Select value={leitoSelecionado} onValueChange={setLeitoSelecionado}>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione o leito" />
+              </SelectTrigger>
+              <SelectContent>
+                {leitos.map((l) => (
+                  <SelectItem key={l.id} value={l.id}>
+                    {l.codigoLeito}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {contatoSucesso !== null && (
+          <DialogFooter>
+            <Button variant="outline" onClick={fechar}>
+              Cancelar
+            </Button>
+            <Button onClick={handleConfirm} disabled={contatoSucesso === false && !motivo || contatoSucesso === true && !leitoSelecionado}>
+              Confirmar
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/modals/RemanejamentoModal.tsx
+++ b/src/components/modals/RemanejamentoModal.tsx
@@ -40,6 +40,7 @@ const options: { value: TipoRemanejamento; label: string }[] = [
   { value: 'adequacao_perfil', label: 'Adequação de Perfil Clínico' },
   { value: 'melhoria_assistencia', label: 'Melhoria na Assistência' },
   { value: 'liberado_isolamento', label: 'Liberado de Isolamento' },
+  { value: 'reserva_oncologia', label: 'Reserva para Oncologia' },
 ];
 
 export const RemanejamentoModal = ({ open, onOpenChange, onConfirm }: RemanejamentoModalProps) => {
@@ -73,6 +74,9 @@ export const RemanejamentoModal = ({ open, onOpenChange, onConfirm }: Remanejame
     }
     if (tipo === 'adequacao_perfil') {
       detalhes.setoresSugeridos = setoresSelecionados;
+    }
+    if (tipo === 'reserva_oncologia') {
+      detalhes.justificativa = 'Reserva para Oncologia';
     }
     onConfirm(detalhes);
     onOpenChange(false);

--- a/src/components/modals/ReservaOncologiaModal.tsx
+++ b/src/components/modals/ReservaOncologiaModal.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import type { useReservaOncologia } from '@/hooks/useReservaOncologia';
+import { ReservaOncologia } from '@/types/reservaOncologia';
+import { LeitoEnriquecido } from '@/types/hospital';
+import { AdicionarEditarReservaModal, ReservaFormData } from './AdicionarEditarReservaModal';
+import { ContatoReservaModal } from './ContatoReservaModal';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  leitos: LeitoEnriquecido[];
+  handleConfirmarReserva: (data: {
+    nomeCompleto: string;
+    dataNascimento: string;
+    sexoPaciente: 'Masculino' | 'Feminino';
+    origem: string;
+  }, leito: LeitoEnriquecido) => Promise<void>;
+  registrarTentativa: ReturnType<typeof useReservaOncologia>['registrarTentativaContato'];
+  marcarComoInternado: ReturnType<typeof useReservaOncologia>['marcarComoInternado'];
+  adicionarReserva: ReturnType<typeof useReservaOncologia>['adicionarReserva'];
+  atualizarReserva: ReturnType<typeof useReservaOncologia>['atualizarReserva'];
+  excluirReserva: ReturnType<typeof useReservaOncologia>['excluirReserva'];
+  reservas: ReservaOncologia[];
+}
+
+export const ReservaOncologiaModal = ({
+  open,
+  onOpenChange,
+  leitos,
+  handleConfirmarReserva,
+  registrarTentativa,
+  marcarComoInternado,
+  adicionarReserva,
+  atualizarReserva,
+  excluirReserva,
+  reservas,
+}: Props) => {
+  const [reservaSelecionada, setReservaSelecionada] = useState<ReservaOncologia | null>(null);
+  const [addEditOpen, setAddEditOpen] = useState(false);
+  const [contatoOpen, setContatoOpen] = useState(false);
+
+  const openAdicionar = () => {
+    setReservaSelecionada(null);
+    setAddEditOpen(true);
+  };
+  const openEditar = (r: ReservaOncologia) => {
+    setReservaSelecionada(r);
+    setAddEditOpen(true);
+  };
+  const openContato = (r: ReservaOncologia) => {
+    setReservaSelecionada(r);
+    setContatoOpen(true);
+  };
+
+  const handleSave = async (data: ReservaFormData) => {
+    if (reservaSelecionada) {
+      await atualizarReserva(reservaSelecionada.id, data);
+    } else {
+      await adicionarReserva(data);
+    }
+  };
+
+  const handleExcluir = async (id: string) => {
+    await excluirReserva(id);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader className="flex justify-between">
+          <DialogTitle>Reservas Oncologia</DialogTitle>
+          <Button onClick={openAdicionar}>Adicionar Reserva</Button>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-auto mt-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Paciente</TableHead>
+                <TableHead>Data Prevista</TableHead>
+                <TableHead>Tentativas</TableHead>
+                <TableHead>Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {reservas.map((r) => {
+                const atrasado = new Date(r.dataPrevistaInternacao) < new Date();
+                return (
+                  <TableRow key={r.id} className={atrasado ? 'text-red-500' : ''}>
+                    <TableCell>{r.nomeCompleto}</TableCell>
+                    <TableCell>{new Date(r.dataPrevistaInternacao).toLocaleDateString()}</TableCell>
+                    <TableCell>
+                      {r.tentativasContato?.map((t, i) => (
+                        <div key={i} className="text-xs">
+                          {new Date(t.data).toLocaleDateString()} - {t.sucesso ? 'Sucesso' : t.motivoFalha}
+                        </div>
+                      ))}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        <Button size="sm" onClick={() => openContato(r)}>Contato</Button>
+                        <Button size="sm" variant="outline" onClick={() => openEditar(r)}>Editar</Button>
+                        <Button size="sm" variant="destructive" onClick={() => handleExcluir(r.id)}>Excluir</Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </DialogContent>
+      <AdicionarEditarReservaModal
+        open={addEditOpen}
+        onOpenChange={setAddEditOpen}
+        onSubmit={handleSave}
+        reserva={reservaSelecionada}
+      />
+      <ContatoReservaModal
+        open={contatoOpen}
+        onOpenChange={setContatoOpen}
+        paciente={reservaSelecionada}
+        leitos={leitos}
+        registrarTentativa={registrarTentativa}
+        onConfirmarReserva={async (pac, leito) => {
+          await handleConfirmarReserva({
+            nomeCompleto: pac.nomeCompleto,
+            dataNascimento: pac.dataNascimento,
+            sexoPaciente: pac.sexo,
+            origem: 'Reserva leito oncologia',
+          }, leito);
+        }}
+        onMarcarInternado={marcarComoInternado}
+      />
+    </Dialog>
+  );
+};

--- a/src/hooks/useReservaOncologia.ts
+++ b/src/hooks/useReservaOncologia.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  query,
+  where,
+  onSnapshot,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  arrayUnion,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { ReservaOncologia, TentativaContato } from '@/types/reservaOncologia';
+import { toast } from '@/hooks/use-toast';
+
+export const useReservaOncologia = () => {
+  const [reservas, setReservas] = useState<ReservaOncologia[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const q = query(
+      collection(db, 'reservaOncologia'),
+      where('status', '==', 'aguardando')
+    );
+
+    const unsub = onSnapshot(q, (snap) => {
+      const data = snap.docs.map((d) => ({ id: d.id, ...d.data() })) as ReservaOncologia[];
+      setReservas(data);
+      setLoading(false);
+    });
+
+    return () => unsub();
+  }, []);
+
+  const adicionarReserva = async (data: Omit<ReservaOncologia, 'id' | 'status' | 'tentativasContato'>) => {
+    try {
+      await addDoc(collection(db, 'reservaOncologia'), {
+        ...data,
+        status: 'aguardando',
+        tentativasContato: [],
+      });
+      toast({ title: 'Sucesso!', description: 'Reserva adicionada.' });
+    } catch (err) {
+      console.error('Erro ao adicionar reserva:', err);
+      toast({ title: 'Erro', description: 'Não foi possível adicionar a reserva.', variant: 'destructive' });
+    }
+  };
+
+  const atualizarReserva = async (id: string, data: Partial<ReservaOncologia>) => {
+    try {
+      await updateDoc(doc(db, 'reservaOncologia', id), data);
+      toast({ title: 'Sucesso!', description: 'Reserva atualizada.' });
+    } catch (err) {
+      console.error('Erro ao atualizar reserva:', err);
+      toast({ title: 'Erro', description: 'Não foi possível atualizar a reserva.', variant: 'destructive' });
+    }
+  };
+
+  const excluirReserva = async (id: string) => {
+    try {
+      await deleteDoc(doc(db, 'reservaOncologia', id));
+      toast({ title: 'Sucesso!', description: 'Reserva excluída.' });
+    } catch (err) {
+      console.error('Erro ao excluir reserva:', err);
+      toast({ title: 'Erro', description: 'Não foi possível excluir a reserva.', variant: 'destructive' });
+    }
+  };
+
+  const registrarTentativaContato = async (id: string, tentativa: TentativaContato) => {
+    try {
+      await updateDoc(doc(db, 'reservaOncologia', id), {
+        tentativasContato: arrayUnion(tentativa),
+      });
+    } catch (err) {
+      console.error('Erro ao registrar tentativa de contato:', err);
+    }
+  };
+
+  const marcarComoInternado = async (id: string) => {
+    try {
+      await updateDoc(doc(db, 'reservaOncologia', id), { status: 'internado' });
+    } catch (err) {
+      console.error('Erro ao marcar como internado:', err);
+    }
+  };
+
+  return {
+    reservas,
+    loading,
+    adicionarReserva,
+    atualizarReserva,
+    excluirReserva,
+    registrarTentativaContato,
+    marcarComoInternado,
+  };
+};

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -6,7 +6,8 @@ export type TipoRemanejamento =
   | 'adequacao_perfil'
   | 'melhoria_assistencia'
   | 'liberado_isolamento'
-  | 'incompatibilidade_biologica';
+  | 'incompatibilidade_biologica'
+  | 'reserva_oncologia';
 
 export interface DetalhesRemanejamento {
   tipo: TipoRemanejamento;

--- a/src/types/reservaOncologia.ts
+++ b/src/types/reservaOncologia.ts
@@ -1,0 +1,24 @@
+export interface TentativaContato {
+  data: string; // ISO format
+  sucesso: boolean;
+  motivoFalha?:
+    | 'CAIXA POSTAL'
+    | 'NÃO RESPONDEU'
+    | 'SINTOMAS RESPIRATÓRIOS'
+    | 'RECUSA PARA INTERNAÇÃO'
+    | 'ÓBITO'
+    | 'SEM MEDICAÇÃO'
+    | 'JÁ INTERNADO';
+}
+
+export interface ReservaOncologia {
+  id: string;
+  nomeCompleto: string;
+  dataNascimento: string;
+  sexo: 'Masculino' | 'Feminino';
+  telefone: string;
+  dataPrevistaInternacao: string;
+  especialidade: 'HEMATOLOGIA' | 'ONCOLOGIA';
+  status: 'aguardando' | 'internado';
+  tentativasContato?: TentativaContato[];
+}


### PR DESCRIPTION
## Summary
- add Firestore hook and types for oncology bed reservations
- create modals for listing, editing and contacting oncology reservation patients
- integrate reservation workflow into MapaLeitos with quick action button and remanejamento option

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ccc07e0c83229fc7b58faf34b615