### PR TITLE
feat: refine alta no leito flow

### DIFF
--- a/src/components/LeitoCard.tsx
+++ b/src/components/LeitoCard.tsx
@@ -14,7 +14,7 @@ import { RemanejamentoModal } from './modals/RemanejamentoModal';
 import { TransferenciaModal } from './modals/TransferenciaModal';
 import { cn } from '@/lib/utils';
 import { LeitoStatusIsolamento } from './LeitoStatusIsolamento';
-import { LeitoEnriquecido, InfoAltaPendente } from '@/types/hospital';
+import { LeitoEnriquecido } from '@/types/hospital';
 
 interface LeitoCardProps {
   leito: LeitoEnriquecido;
@@ -33,23 +33,6 @@ const calcularIdade = (dataNascimento: string): string => {
     return idade.toString();
 };
 
-const descreverAltaPendente = (info: InfoAltaPendente | null | undefined): string => {
-    if (!info) return '';
-    switch (info.tipo) {
-        case 'medicacao':
-            return `Finalizando medicação${info.detalhe ? ` às ${info.detalhe}` : ''}`;
-        case 'transporte':
-            return `Aguardando transporte${info.detalhe ? ` de ${info.detalhe}` : ''}`;
-        case 'familiar':
-            return 'Aguardando familiar';
-        case 'emad':
-            return 'Aguardando EMAD';
-        case 'outros':
-            return info.detalhe || 'Outros';
-        default:
-            return '';
-    }
-};
 
 const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
     const [motivoBloqueioModalOpen, setMotivoBloqueioModalOpen] = useState(false);
@@ -485,17 +468,21 @@ const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
                         variant="ghost"
                         size="icon"
                         className="h-8 w-8"
-                        onClick={() => actions.onAltaPendente(paciente!)}
+                        onClick={() =>
+                          paciente?.altaNoLeito?.status
+                            ? actions.onCancelarAltaNoLeito(paciente!.id)
+                            : actions.onAltaNoLeito(leito)
+                        }
                       >
-                        <PlaneTakeoff className={`h-4 w-4 ${paciente?.altaPendente ? 'text-blue-500' : ''}`} />
+                        <PlaneTakeoff
+                          className={`h-4 w-4 ${
+                            paciente?.altaNoLeito?.status ? 'text-blue-500' : ''
+                          }`}
+                        />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>
-                        {paciente?.altaPendente
-                          ? descreverAltaPendente(paciente.altaPendente)
-                          : 'Registrar pendência de alta'}
-                      </p>
+                      <p>{paciente?.altaNoLeito?.status ? paciente.altaNoLeito.pendencia : 'Alta no leito'}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>

--- a/src/components/modals/AltaNoLeitoModal.tsx
+++ b/src/components/modals/AltaNoLeitoModal.tsx
@@ -1,9 +1,10 @@
-
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 
 interface Props {
   open: boolean;
@@ -12,51 +13,132 @@ interface Props {
   onConfirm: (pendencia: string) => void;
 }
 
-export const AltaNoLeitoModal = ({ 
-  open, 
-  onOpenChange, 
-  pacienteNome, 
-  onConfirm 
-}: Props) => {
-  const [pendencia, setPendencia] = useState('');
+export const AltaNoLeitoModal = ({ open, onOpenChange, pacienteNome, onConfirm }: Props) => {
+  const [tipo, setTipo] = useState<'medicacao' | 'transporte' | 'familiar' | 'emad' | 'outros'>('medicacao');
+  const [detalhe, setDetalhe] = useState('');
+
+  const resetar = () => {
+    setTipo('medicacao');
+    setDetalhe('');
+  };
 
   const handleConfirm = () => {
-    if (pendencia.trim()) {
-      onConfirm(pendencia.trim());
-      setPendencia('');
-      onOpenChange(false);
+    let pendencia = '';
+    switch (tipo) {
+      case 'medicacao':
+        pendencia = `Finalizando medicação${detalhe ? ` às ${detalhe}` : ''}`;
+        break;
+      case 'transporte':
+        pendencia = `Aguardando transporte${detalhe ? ` de ${detalhe}` : ''}`;
+        break;
+      case 'familiar':
+        pendencia = 'Aguardando Familiar';
+        break;
+      case 'emad':
+        pendencia = 'Aguardando EMAD';
+        break;
+      case 'outros':
+        pendencia = detalhe;
+        break;
     }
+
+    onConfirm(pendencia);
+    resetar();
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    resetar();
+    onOpenChange(false);
+  };
+
+  const confirmDisabled = () => {
+    if (tipo === 'medicacao' && !detalhe) return true;
+    if (tipo === 'transporte' && !detalhe.trim()) return true;
+    if (tipo === 'outros' && !detalhe.trim()) return true;
+    return false;
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+    <Dialog open={open} onOpenChange={handleCancel}>
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Alta no Leito - {pacienteNome}</DialogTitle>
+          <DialogTitle className="text-lg font-semibold text-medical-primary">
+            Alta no Leito - {pacienteNome}
+          </DialogTitle>
         </DialogHeader>
-        
+
         <div className="space-y-4 py-4">
-          <div className="space-y-2">
-            <Label htmlFor="pendencia">Descreva a pendência para a alta:</Label>
-            <Textarea
-              id="pendencia"
-              value={pendencia}
-              onChange={(e) => setPendencia(e.target.value)}
-              placeholder="Ex: Aguardando familiar, Aguardando transporte, Realizando medicação..."
-              className="min-h-[100px]"
-            />
-          </div>
+          <RadioGroup
+            value={tipo}
+            onValueChange={(v) => {
+              setTipo(v as 'medicacao' | 'transporte' | 'familiar' | 'emad' | 'outros');
+              setDetalhe('');
+            }}
+            className="space-y-2"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="medicacao" id="medicacao" />
+              <Label htmlFor="medicacao">Finalizando Medicação</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="transporte" id="transporte" />
+              <Label htmlFor="transporte">Aguardando Transporte</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="familiar" id="familiar" />
+              <Label htmlFor="familiar">Aguardando Familiar</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="emad" id="emad" />
+              <Label htmlFor="emad">Aguardando EMAD</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="outros" id="outros" />
+              <Label htmlFor="outros">Outros</Label>
+            </div>
+          </RadioGroup>
+
+          {tipo === 'medicacao' && (
+            <div className="space-y-2">
+              <Label htmlFor="horaMedicacao">Horário da Medicação</Label>
+              <Input
+                id="horaMedicacao"
+                type="time"
+                value={detalhe}
+                onChange={(e) => setDetalhe(e.target.value)}
+              />
+            </div>
+          )}
+          {tipo === 'transporte' && (
+            <div className="space-y-2">
+              <Label htmlFor="municipio">Município</Label>
+              <Input
+                id="municipio"
+                placeholder="Município..."
+                value={detalhe}
+                onChange={(e) => setDetalhe(e.target.value)}
+              />
+            </div>
+          )}
+          {tipo === 'outros' && (
+            <div className="space-y-2">
+              <Label htmlFor="detalhe">Detalhe</Label>
+              <Textarea id="detalhe" value={detalhe} onChange={(e) => setDetalhe(e.target.value)} />
+            </div>
+          )}
         </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+        <DialogFooter className="flex justify-end space-x-2">
+          <Button variant="outline" onClick={handleCancel}>
             Cancelar
           </Button>
-          <Button onClick={handleConfirm} disabled={!pendencia.trim()}>
-            Confirmar Alta no Leito
+          <Button onClick={handleConfirm} disabled={confirmDisabled()}>
+            Confirmar
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 };
+


### PR DESCRIPTION
## Summary
- rename action text to "Alta no leito" and toggle when active
- capture all alta no leito justification options
- allow cancelling alta no leito entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d245a67483229521f258712e455a