### PR TITLE
Refatora fluxo de alta no leito

### DIFF
--- a/src/components/huddle/PacientesEmFluxoDeAlta.tsx
+++ b/src/components/huddle/PacientesEmFluxoDeAlta.tsx
@@ -37,11 +37,11 @@ export const PacientesEmFluxoDeAlta = ({
   const altasNoLeito = pacientes
     .filter(p => p.altaNoLeito?.status)
     .reduce((acc, paciente) => {
-      const pendencia = paciente.altaNoLeito!.pendencia;
-      if (!acc[pendencia]) {
-        acc[pendencia] = [];
+      const tipo = paciente.altaNoLeito!.tipo;
+      if (!acc[tipo]) {
+        acc[tipo] = [];
       }
-      acc[pendencia].push(paciente);
+      acc[tipo].push(paciente);
       return acc;
     }, {} as Record<string, Paciente[]>);
 
@@ -160,11 +160,11 @@ export const PacientesEmFluxoDeAlta = ({
                 </p>
               ) : (
                 <Accordion type="multiple" className="w-full">
-                  {Object.entries(altasNoLeito).map(([pendencia, pacientes]) => (
-                    <AccordionItem key={pendencia} value={pendencia}>
+                  {Object.entries(altasNoLeito).map(([tipo, pacientes]) => (
+                    <AccordionItem key={tipo} value={tipo}>
                       <AccordionTrigger className="text-left">
                         <div className="flex items-center gap-2">
-                          <span className="font-medium">{motivoLabels[pendencia] || pendencia}</span>
+                          <span className="font-medium">{motivoLabels[tipo] || tipo}</span>
                           <Badge variant="outline">{pacientes.length}</Badge>
                         </div>
                       </AccordionTrigger>

--- a/src/components/modals/AltaNoLeitoModal.tsx
+++ b/src/components/modals/AltaNoLeitoModal.tsx
@@ -5,12 +5,15 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { AltaLeitoInfo } from '@/types/hospital';
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   pacienteNome: string;
-  onConfirm: (pendencia: string) => void;
+  onConfirm: (
+    dados: Pick<AltaLeitoInfo, 'tipo' | 'detalhe' | 'pendencia'>
+  ) => void;
 }
 
 export const AltaNoLeitoModal = ({ open, onOpenChange, pacienteNome, onConfirm }: Props) => {
@@ -42,7 +45,13 @@ export const AltaNoLeitoModal = ({ open, onOpenChange, pacienteNome, onConfirm }
         break;
     }
 
-    onConfirm(pendencia);
+    const dadosAlta: Pick<AltaLeitoInfo, 'tipo' | 'detalhe' | 'pendencia'> = {
+      tipo,
+      detalhe,
+      pendencia,
+    };
+
+    onConfirm(dadosAlta);
     resetar();
     onOpenChange(false);
   };

--- a/src/pages/MapaLeitos.tsx
+++ b/src/pages/MapaLeitos.tsx
@@ -512,12 +512,16 @@ const MapaLeitos = () => {
     }
   };
 
-  const handleConfirmarAltaNoLeito = async (pendencia: string) => {
+  const handleConfirmarAltaNoLeito = async (
+    dadosAlta: Pick<AltaLeitoInfo, 'tipo' | 'detalhe' | 'pendencia'>
+  ) => {
     if (pacienteParaAltaNoLeito?.dadosPaciente && userData) {
       try {
         const altaLeitoInfo: AltaLeitoInfo = {
           status: true,
-          pendencia,
+          tipo: dadosAlta.tipo,
+          detalhe: dadosAlta.detalhe,
+          pendencia: dadosAlta.pendencia,
           timestamp: new Date().toISOString(),
           usuario: userData.nomeCompleto
         };

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -17,7 +17,9 @@ export interface DetalhesRemanejamento {
 
 export interface AltaLeitoInfo {
   status: boolean;
-  pendencia: string;
+  tipo: 'medicacao' | 'transporte' | 'familiar' | 'emad' | 'outros';
+  detalhe?: string; // Detalhe adicional da pendência
+  pendencia: string; // Texto completo para exibição rápida
   timestamp: string; // Data e hora no formato ISO
   usuario: string; // Nome do usuário que registrou
 }


### PR DESCRIPTION
## Summary
- Estrutura `AltaLeitoInfo` com campos de tipo e detalhe
- Ajusta modal de Alta no Leito para enviar objeto estruturado
- Persiste informações estruturadas e agrupa pacientes por tipo no Huddle

## Testing
- `npm test` (erro: Missing script: "test")
- `npm run lint` (erros de lint encontrados)


------
https://chatgpt.com/codex/tasks/task_e_68b2ddc1dde88322bceb51cd8b2c97b9