### PR TITLE
feat: add contra-fluxo option and simplify remanejamento modal

### DIFF
--- a/src/components/modals/RemanejamentoModal.tsx
+++ b/src/components/modals/RemanejamentoModal.tsx
@@ -11,22 +11,6 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from '@/components/ui/popover';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { Check } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useSetores } from '@/hooks/useSetores';
 import type { DetalhesRemanejamento, TipoRemanejamento } from '@/types/hospital';
 
 interface RemanejamentoModalProps {
@@ -39,6 +23,7 @@ const options: { value: TipoRemanejamento; label: string }[] = [
   { value: 'priorizacao', label: 'Pedido de Priorização' },
   { value: 'adequacao_perfil', label: 'Adequação de Perfil Clínico' },
   { value: 'melhoria_assistencia', label: 'Melhoria na Assistência' },
+  { value: 'contra_fluxo', label: 'Contra-fluxo' },
   { value: 'liberado_isolamento', label: 'Liberado de Isolamento' },
   { value: 'reserva_oncologia', label: 'Reserva para Oncologia' },
   { value: 'alta_uti', label: 'Alta da UTI' },
@@ -47,43 +32,38 @@ const options: { value: TipoRemanejamento; label: string }[] = [
 export const RemanejamentoModal = ({ open, onOpenChange, onConfirm }: RemanejamentoModalProps) => {
   const [tipo, setTipo] = useState<TipoRemanejamento>('priorizacao');
   const [justificativa, setJustificativa] = useState('');
-  const [setoresSelecionados, setSetoresSelecionados] = useState<string[]>([]);
-  const { setores } = useSetores();
-
-  const toggleSetor = (id: string) => {
-    setSetoresSelecionados((prev) =>
-      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
-    );
-  };
-
   const isValid = () => {
-    switch (tipo) {
-      case 'priorizacao':
-      case 'melhoria_assistencia':
-        return justificativa.trim().length > 0;
-      case 'adequacao_perfil':
-        return setoresSelecionados.length > 0;
-      default:
-        return true;
+    const precisaJustificativa = [
+      'priorizacao',
+      'melhoria_assistencia',
+      'adequacao_perfil',
+      'contra_fluxo',
+    ].includes(tipo);
+
+    if (precisaJustificativa) {
+      return justificativa.trim().length > 0;
     }
+
+    return true;
   };
 
   const handleConfirm = () => {
+    const precisaJustificativa = [
+      'priorizacao',
+      'melhoria_assistencia',
+      'adequacao_perfil',
+      'contra_fluxo',
+    ].includes(tipo);
+
     const detalhes: DetalhesRemanejamento = { tipo };
-    if (tipo === 'priorizacao' || tipo === 'melhoria_assistencia') {
+    if (precisaJustificativa) {
       detalhes.justificativa = justificativa;
     }
-    if (tipo === 'adequacao_perfil') {
-      detalhes.setoresSugeridos = setoresSelecionados;
-    }
-    if (tipo === 'reserva_oncologia') {
-      detalhes.justificativa = 'Reserva para Oncologia';
-    }
+
     onConfirm(detalhes);
     onOpenChange(false);
     setTipo('priorizacao');
     setJustificativa('');
-    setSetoresSelecionados([]);
   };
 
   return (
@@ -105,72 +85,20 @@ export const RemanejamentoModal = ({ open, onOpenChange, onConfirm }: Remanejame
             ))}
           </RadioGroup>
 
-          {tipo === 'priorizacao' && (
+          {['priorizacao', 'melhoria_assistencia', 'adequacao_perfil', 'contra_fluxo'].includes(tipo) && (
             <div className="space-y-2">
-              <Label htmlFor="just-priorizacao">Quem solicitou e o motivo</Label>
+              <Label htmlFor="justificativa">
+                {tipo === 'priorizacao'
+                  ? 'Quem solicitou e o motivo'
+                  : tipo === 'melhoria_assistencia'
+                  ? 'Justificativa clínica'
+                  : 'Justificativa'}
+              </Label>
               <Textarea
-                id="just-priorizacao"
+                id="justificativa"
                 value={justificativa}
                 onChange={(e) => setJustificativa(e.target.value)}
               />
-            </div>
-          )}
-
-          {tipo === 'melhoria_assistencia' && (
-            <div className="space-y-2">
-              <Label htmlFor="just-melhoria">Justificativa clínica</Label>
-              <Textarea
-                id="just-melhoria"
-                value={justificativa}
-                onChange={(e) => setJustificativa(e.target.value)}
-              />
-            </div>
-          )}
-
-          {tipo === 'adequacao_perfil' && (
-            <div className="space-y-2">
-              <Label>Setor(es) sugerido(s)</Label>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full justify-start font-normal"
-                  >
-                    {setoresSelecionados.length > 0
-                      ? `${setoresSelecionados.length} selecionado(s)`
-                      : 'Selecione o(s) setor(es)'}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-                  <Command onPointerDown={(e) => e.stopPropagation()}>
-                    <CommandInput placeholder="Buscar setor..." />
-                    <CommandList>
-                      <CommandEmpty>Nenhum setor encontrado.</CommandEmpty>
-                      <CommandGroup>
-                        {setores.map((setor) => (
-                          <CommandItem
-                            key={setor.id}
-                            value={setor.nomeSetor}
-                            onSelect={() => toggleSetor(setor.id)}
-                          >
-                            <div
-                              className={cn(
-                                'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                                setoresSelecionados.includes(setor.id)
-                                  ? 'bg-primary text-primary-foreground'
-                                  : 'opacity-50 [&_svg]:invisible'
-                              )}
-                            >
-                              <Check className="h-4 w-4" />
-                            </div>
-                            {setor.nomeSetor}
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                </PopoverContent>
-              </Popover>
             </div>
           )}
         </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,17 +70,25 @@ export const descreverMotivoRemanejamento = (
         ? `Pedido de Priorização: ${detalhes.justificativa}`
         : 'Pedido de Priorização';
     case 'adequacao_perfil':
-      return detalhes.setoresSugeridos?.length
-        ? `Adequação de Perfil Clínico: ${detalhes.setoresSugeridos.join(', ')}`
+      return detalhes.justificativa
+        ? `Adequação de Perfil Clínico: ${detalhes.justificativa}`
         : 'Adequação de Perfil Clínico';
     case 'melhoria_assistencia':
       return detalhes.justificativa
         ? `Melhoria na Assistência: ${detalhes.justificativa}`
         : 'Melhoria na Assistência';
+    case 'contra_fluxo':
+      return detalhes.justificativa
+        ? `Contra-fluxo: ${detalhes.justificativa}`
+        : 'Contra-fluxo';
     case 'liberado_isolamento':
       return 'Liberado de Isolamento';
     case 'incompatibilidade_biologica':
       return 'Incompatibilidade Biológica';
+    case 'reserva_oncologia':
+      return 'Reserva para Oncologia';
+    case 'alta_uti':
+      return 'Alta da UTI';
     default:
       return '';
   }

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -5,6 +5,7 @@ export type TipoRemanejamento =
   | 'priorizacao'
   | 'adequacao_perfil'
   | 'melhoria_assistencia'
+  | 'contra_fluxo'
   | 'liberado_isolamento'
   | 'incompatibilidade_biologica'
   | 'reserva_oncologia'
@@ -13,7 +14,6 @@ export type TipoRemanejamento =
 export interface DetalhesRemanejamento {
   tipo: TipoRemanejamento;
   justificativa?: string;
-  setoresSugeridos?: string[];
 }
 
 export interface AltaLeitoInfo {


### PR DESCRIPTION
## Summary
- include `contra_fluxo` in remanejamento types and modal options
- replace setor combobox with free-text justification
- adjust remanejamento description helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e544afc88322a03de0b2ac15acac