### PR TITLE
feat: solicitar motivo ao cancelar reserva externa

### DIFF
--- a/src/components/LeitoCard.tsx
+++ b/src/components/LeitoCard.tsx
@@ -365,30 +365,21 @@ const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
                   </AlertDialogContent>
                 </AlertDialog>
                 
-                <AlertDialog>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <AlertDialogTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-8 w-8">
-                            <XCircle className="h-4 w-4" />
-                          </Button>
-                        </AlertDialogTrigger>
-                      </TooltipTrigger>
-                      <TooltipContent><p>Cancelar Reserva</p></TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Cancelar Reserva</AlertDialogTitle>
-                      <AlertDialogDescription>Deseja cancelar a reserva do leito {leito.codigoLeito} para {leito.dadosPaciente?.nomeCompleto}?</AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Não</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => actions.onCancelarReserva(leito.id)}>Cancelar Reserva</AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => actions.onCancelarReserva(leito)}
+                      >
+                        <XCircle className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent><p>Cancelar Reserva</p></TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </div>
             )}
             

--- a/src/components/modals/CancelamentoReservaModal.tsx
+++ b/src/components/modals/CancelamentoReservaModal.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (motivo: string) => void;
+}
+
+export const CancelamentoReservaModal = ({ open, onOpenChange, onConfirm }: Props) => {
+  const [motivo, setMotivo] = useState('');
+
+  const handleConfirm = () => {
+    if (motivo.trim()) {
+      onConfirm(motivo.trim());
+      setMotivo('');
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Motivo do Cancelamento</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <Textarea
+            placeholder="Descreva o motivo do cancelamento..."
+            value={motivo}
+            onChange={(e) => setMotivo(e.target.value)}
+            className="min-h-[100px]"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="destructive" onClick={handleConfirm} disabled={!motivo.trim()}>
+            Confirmar Cancelamento
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CancelamentoReservaModal;


### PR DESCRIPTION
## Summary
- coletar motivo ao cancelar reserva externa
- registrar motivo no log de auditoria
- atualizar botão de cancelamento no card do leito

## Testing
- `npm run lint` *(fails: Unexpected any and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ed43ddc883229f4a5e0ee6ab5cb7