### PR TITLE
feat: restore pending reallocation block

### DIFF
--- a/src/components/RemanejamentoPendenteItem.tsx
+++ b/src/components/RemanejamentoPendenteItem.tsx
@@ -1,10 +1,10 @@
 
-import React from 'react';
-import { Paciente } from '@/types/hospital';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { CalendarClock, MapPin } from 'lucide-react';
-import { descreverMotivoRemanejamento } from '@/lib/utils';
+import React from "react";
+import { Paciente } from "@/types/hospital";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { CalendarClock, MapPin } from "lucide-react";
+import { descreverMotivoRemanejamento } from "@/lib/utils";
 
 interface RemanejamentoPendenteItemProps {
   paciente: Paciente & {
@@ -12,16 +12,14 @@ interface RemanejamentoPendenteItemProps {
     siglaSetorOrigem?: string;
     leitoCodigo?: string;
   };
-  onConfirmar: (paciente: Paciente) => void;
+  onRemanejar: (paciente: Paciente) => void;
   onCancelar: (paciente: Paciente) => void;
-  onObservacoes: (paciente: Paciente) => void;
 }
 
-export const RemanejamentoPendenteItem = ({ 
-  paciente, 
-  onConfirmar, 
-  onCancelar, 
-  onObservacoes 
+export const RemanejamentoPendenteItem = ({
+  paciente,
+  onRemanejar,
+  onCancelar,
 }: RemanejamentoPendenteItemProps) => {
   const prioridadeCores = {
     'Muito Urgente': 'bg-red-500 text-white',
@@ -70,14 +68,11 @@ export const RemanejamentoPendenteItem = ({
       </div>
 
       <div className="mt-4 flex justify-end gap-2">
-        <Button size="sm" variant="outline" onClick={() => onObservacoes(paciente)}>
-          Observações
-        </Button>
         <Button size="sm" variant="destructive" onClick={() => onCancelar(paciente)}>
           Cancelar
         </Button>
-        <Button size="sm" onClick={() => onConfirmar(paciente)}>
-          Confirmar Remanejamento
+        <Button size="sm" onClick={() => onRemanejar(paciente)}>
+          Remanejar
         </Button>
       </div>
     </div>

--- a/src/components/RemanejamentosPendentesBloco.tsx
+++ b/src/components/RemanejamentosPendentesBloco.tsx
@@ -2,23 +2,33 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { RemanejamentoPendenteItem } from "@/components/RemanejamentoPendenteItem";
-import { Paciente } from '@/types/hospital';
+import { Paciente } from "@/types/hospital";
+import { descreverMotivoRemanejamento } from "@/lib/utils";
 
 interface RemanejamentosPendentesBlocoProps {
-  remanejamentosPendentes: Paciente[];
-  onConfirmarRemanejamento: (paciente: Paciente) => void;
-  onCancelarRemanejamento: (paciente: Paciente) => void;
-  onObservacoesRemanejamento: (paciente: Paciente) => void;
+  remanejamentos: Paciente[];
+  onRemanejar: (paciente: Paciente) => void;
+  onCancelar: (paciente: Paciente) => void;
 }
 
-export const RemanejamentosPendentesBloco = ({ 
-  remanejamentosPendentes = [], 
-  onConfirmarRemanejamento, 
-  onCancelarRemanejamento, 
-  onObservacoesRemanejamento 
+export const RemanejamentosPendentesBloco = ({
+  remanejamentos = [],
+  onRemanejar,
+  onCancelar,
 }: RemanejamentosPendentesBlocoProps) => {
-  // Garantir que remanejamentosPendentes é sempre um array
-  const remanejamentos = Array.isArray(remanejamentosPendentes) ? remanejamentosPendentes : [];
+  const grupos = remanejamentos.reduce(
+    (acc, paciente) => {
+      const motivoBase = descreverMotivoRemanejamento(
+        paciente.motivoRemanejamento
+      )
+        .split(":")[0]
+        .trim() || "Outro";
+      if (!acc[motivoBase]) acc[motivoBase] = [];
+      acc[motivoBase].push(paciente);
+      return acc;
+    },
+    {} as Record<string, Paciente[]>
+  );
 
   if (remanejamentos.length === 0) {
     return null;
@@ -33,17 +43,21 @@ export const RemanejamentosPendentesBloco = ({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="space-y-4">
-          {remanejamentos.map((paciente) => (
-            <RemanejamentoPendenteItem
-              key={paciente.id}
-              paciente={paciente}
-              onConfirmar={onConfirmarRemanejamento}
-              onCancelar={onCancelarRemanejamento}
-              onObservacoes={onObservacoesRemanejamento}
-            />
-          ))}
-        </div>
+        {Object.entries(grupos).map(([motivo, pacientes]) => (
+          <div key={motivo} className="mb-6 last:mb-0">
+            <h3 className="font-medium text-medical-primary mb-2">{motivo}</h3>
+            <div className="space-y-4">
+              {pacientes.map((paciente) => (
+                <RemanejamentoPendenteItem
+                  key={paciente.id}
+                  paciente={paciente}
+                  onRemanejar={onRemanejar}
+                  onCancelar={onCancelar}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
       </CardContent>
     </Card>
   );

--- a/src/hooks/useRegulacaoLogic.ts
+++ b/src/hooks/useRegulacaoLogic.ts
@@ -420,7 +420,7 @@ const registrarHistoricoRegulacao = async (
   const pacientesAguardandoTransferencia = filteredPacientes.filter(
     (p) => p.transferirPaciente
   );
-  const pacientesAguardandoRemanejamento = filteredPacientes.filter(
+  const remanejamentosPendentes = filteredPacientes.filter(
     (p) => p.remanejarPaciente && p.statusLeito !== 'Regulado'
   );
   const decisaoCirurgica = pacientesAguardandoRegulacao.filter(
@@ -440,14 +440,14 @@ const registrarHistoricoRegulacao = async (
       ...pacientesJaRegulados,
       ...pacientesAguardandoUTI,
       ...pacientesAguardandoTransferencia,
-      ...pacientesAguardandoRemanejamento,
+      ...remanejamentosPendentes,
     ],
     [
       pacientesAguardandoRegulacao,
       pacientesJaRegulados,
       pacientesAguardandoUTI,
       pacientesAguardandoTransferencia,
-      pacientesAguardandoRemanejamento,
+      remanejamentosPendentes,
     ]
   );
 
@@ -1509,7 +1509,7 @@ const registrarHistoricoRegulacao = async (
       pacientesAguardandoRegulacao,
       pacientesAguardandoUTI,
       pacientesAguardandoTransferencia,
-      pacientesAguardandoRemanejamento,
+      remanejamentosPendentes,
       pacientesJaRegulados,
       decisaoCirurgica,
       decisaoClinica,

--- a/src/pages/RegulacaoLeitos.tsx
+++ b/src/pages/RegulacaoLeitos.tsx
@@ -298,24 +298,20 @@ const RegulacaoLeitos = () => {
           onGerenciarTransferencia={handlers.handleGerenciarTransferencia}
         />
 
-        {/* 7. Bloco: Pacientes Aguardando Cirurgia Eletiva */}
+        {/* 7. Bloco: Remanejamentos Pendentes */}
+        <RemanejamentosPendentesBloco
+          remanejamentos={listas.remanejamentosPendentes}
+          onRemanejar={(paciente) =>
+            handlers.handleOpenRegulacaoModal(paciente, "normal")
+          }
+          onCancelar={handlers.handleCancelarRemanejamento}
+        />
+
+        {/* 8. Bloco: Pacientes Aguardando Cirurgia Eletiva */}
         <CirurgiasEletivasBloco
           cirurgias={listas.cirurgias}
           onAlocarCirurgia={handlers.handleAlocarLeitoCirurgia}
         />
-
-        {/* 8. Bloco: Remanejamentos Pendentes */}
-        {listas.pacientesAguardandoRemanejamento.length > 0 && (
-          <RemanejamentosPendentesBloco
-            pacientesAguardandoRemanejamento={
-              listas.pacientesAguardandoRemanejamento
-            }
-            onRemanejar={(paciente) =>
-              handlers.handleOpenRegulacaoModal(paciente, "normal")
-            }
-            onCancelar={handlers.handleCancelarRemanejamento}
-          />
-        )}
 
         {/* Modais */}
         <RegulacaoModals


### PR DESCRIPTION
## Summary
- restore pending reallocation block on bed regulation page
- add grouping logic and actions for pending reallocation requests
- expose pending reallocation list from regulation logic hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b31087e82c83228320d723f361b3fd