### PR TITLE
feat: improve pending transfers accordion

### DIFF
--- a/src/components/RemanejamentoPendenteItem.tsx
+++ b/src/components/RemanejamentoPendenteItem.tsx
@@ -2,9 +2,7 @@
 import React from "react";
 import { Paciente } from "@/types/hospital";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { CalendarClock, MapPin } from "lucide-react";
-import { descreverMotivoRemanejamento } from "@/lib/utils";
+import { descreverMotivoRemanejamento, formatarDuracao } from "@/lib/utils";
 
 interface RemanejamentoPendenteItemProps {
   paciente: Paciente & {
@@ -21,56 +19,38 @@ export const RemanejamentoPendenteItem = ({
   onRemanejar,
   onCancelar,
 }: RemanejamentoPendenteItemProps) => {
-  const prioridadeCores = {
-    'Muito Urgente': 'bg-red-500 text-white',
-    'Urgente': 'bg-orange-500 text-white',
-    'Normal': 'bg-yellow-500 text-gray-800',
-    'Baixa': 'bg-green-500 text-white',
-  };
+  const motivo = descreverMotivoRemanejamento(paciente.motivoRemanejamento);
+  const isRiscoContaminacao = motivo
+    .toLowerCase()
+    .startsWith("risco de contaminação cruzada");
 
   return (
-    <div className="bg-white p-4 rounded-lg border-l-4 border-blue-400 shadow-sm hover:shadow-md transition-shadow">
-      <div className="flex justify-between items-start mb-3">
-        <div>
-          <h3 className="font-semibold text-lg text-gray-800">{paciente.nomeCompleto}</h3>
-          <div className="flex items-center gap-2 text-sm text-gray-600 mt-1">
-            <MapPin className="h-4 w-4" />
-            <span>
-              {paciente.setorOrigem || paciente.siglaSetorOrigem || 'Setor não informado'} - 
-              Leito {paciente.leitoCodigo || 'N/A'}
-            </span>
-          </div>
-        </div>
-        <Badge 
-          variant="secondary" 
-          className="text-xs font-semibold"
-        >
-          REMANEJAMENTO
-        </Badge>
-      </div>
-
-      <div className="mt-2">
-        <p className="text-gray-700 text-sm mb-2">
-          <strong>Motivo:</strong> {descreverMotivoRemanejamento(paciente.motivoRemanejamento)}
+    <div className="flex items-center justify-between gap-4 p-3 rounded-lg border bg-white shadow-sm hover:shadow-md transition-shadow">
+      <div className="flex flex-col flex-grow min-w-0 gap-1">
+        <p className="font-semibold text-base truncate" title={paciente.nomeCompleto}>
+          {paciente.nomeCompleto}
         </p>
-        <p className="text-gray-700 text-sm">
-          <strong>Especialidade:</strong> {paciente.especialidadePaciente}
+        <p className="text-sm text-muted-foreground truncate">
+          {paciente.setorOrigem || paciente.siglaSetorOrigem || 'Setor não informado'} - Leito {paciente.leitoCodigo || 'N/A'}
+        </p>
+        <p className="text-sm text-muted-foreground truncate">
+          Motivo: {motivo}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Aguardando há {formatarDuracao(paciente.dataPedidoRemanejamento)}
         </p>
       </div>
 
-      <div className="flex items-center text-gray-600 text-xs mt-3">
-        <CalendarClock className="mr-1 h-4 w-4" />
-        Solicitado em: {
-          paciente.dataPedidoRemanejamento 
-            ? new Date(paciente.dataPedidoRemanejamento).toLocaleDateString('pt-BR')
-            : 'Data não informada'
-        }
-      </div>
-
-      <div className="mt-4 flex justify-end gap-2">
-        <Button size="sm" variant="destructive" onClick={() => onCancelar(paciente)}>
-          Cancelar
-        </Button>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {!isRiscoContaminacao && (
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => onCancelar(paciente)}
+          >
+            Cancelar
+          </Button>
+        )}
         <Button size="sm" onClick={() => onRemanejar(paciente)}>
           Remanejar
         </Button>

--- a/src/components/RemanejamentosPendentesBloco.tsx
+++ b/src/components/RemanejamentosPendentesBloco.tsx
@@ -4,6 +4,12 @@ import { Badge } from "@/components/ui/badge";
 import { RemanejamentoPendenteItem } from "@/components/RemanejamentoPendenteItem";
 import { Paciente } from "@/types/hospital";
 import { descreverMotivoRemanejamento } from "@/lib/utils";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 interface RemanejamentosPendentesBlocoProps {
   remanejamentos: Paciente[];
@@ -18,11 +24,17 @@ export const RemanejamentosPendentesBloco = ({
 }: RemanejamentosPendentesBlocoProps) => {
   const grupos = remanejamentos.reduce(
     (acc, paciente) => {
-      const motivoBase = descreverMotivoRemanejamento(
+      const motivoCompleto = descreverMotivoRemanejamento(
         paciente.motivoRemanejamento
-      )
-        .split(":")[0]
-        .trim() || "Outro";
+      );
+      let motivoBase = motivoCompleto.split(":")[0].trim() || "Outro";
+      if (
+        motivoCompleto
+          .toLowerCase()
+          .startsWith("risco de contaminação cruzada")
+      ) {
+        motivoBase = "Risco de Contaminação Cruzada";
+      }
       if (!acc[motivoBase]) acc[motivoBase] = [];
       acc[motivoBase].push(paciente);
       return acc;
@@ -36,29 +48,46 @@ export const RemanejamentosPendentesBloco = ({
 
   return (
     <Card className="shadow-card border border-border/50">
-      <CardHeader>
-        <CardTitle className="text-xl font-semibold text-medical-primary flex items-center gap-2">
-          Remanejamentos Pendentes
-          <Badge variant="secondary">{remanejamentos.length}</Badge>
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {Object.entries(grupos).map(([motivo, pacientes]) => (
-          <div key={motivo} className="mb-6 last:mb-0">
-            <h3 className="font-medium text-medical-primary mb-2">{motivo}</h3>
-            <div className="space-y-4">
-              {pacientes.map((paciente) => (
-                <RemanejamentoPendenteItem
-                  key={paciente.id}
-                  paciente={paciente}
-                  onRemanejar={onRemanejar}
-                  onCancelar={onCancelar}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-      </CardContent>
+      <Accordion type="single" collapsible>
+        <AccordionItem value="remanejamentos">
+          <CardHeader className="p-0">
+            <AccordionTrigger className="px-6">
+              <CardTitle className="text-xl font-semibold text-medical-primary flex items-center gap-2">
+                Remanejamentos Pendentes
+                <Badge variant="secondary">{remanejamentos.length}</Badge>
+              </CardTitle>
+            </AccordionTrigger>
+          </CardHeader>
+          <AccordionContent>
+            <CardContent className="pt-4">
+              <Accordion type="multiple" className="space-y-2" collapsible>
+                {Object.entries(grupos).map(([motivo, pacientes]) => (
+                  <AccordionItem value={motivo} key={motivo}>
+                    <AccordionTrigger className="text-left">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-medical-primary">{motivo}</span>
+                        <Badge variant="secondary">{pacientes.length}</Badge>
+                      </div>
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                        {pacientes.map((paciente) => (
+                          <RemanejamentoPendenteItem
+                            key={paciente.id}
+                            paciente={paciente}
+                            onRemanejar={onRemanejar}
+                            onCancelar={onCancelar}
+                          />
+                        ))}
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </CardContent>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </Card>
   );
 };

--- a/src/hooks/useRegulacaoLogic.ts
+++ b/src/hooks/useRegulacaoLogic.ts
@@ -423,6 +423,32 @@ const registrarHistoricoRegulacao = async (
   const remanejamentosPendentes = filteredPacientes.filter(
     (p) => p.remanejarPaciente && p.statusLeito !== 'Regulado'
   );
+
+  // Agrupa os remanejamentos pendentes por motivo base, aplicando
+  // tratamento especial para qualquer variação que comece com
+  // "Risco de contaminação cruzada". Esses casos são agrupados
+  // sob o nome fixo "Risco de Contaminação Cruzada".
+  const remanejamentosAgrupados = remanejamentosPendentes.reduce(
+    (acc, paciente) => {
+      const motivoCompleto = descreverMotivoRemanejamento(
+        paciente.motivoRemanejamento
+      );
+
+      let grupo = motivoCompleto.split(':')[0].trim() || 'Outro';
+      if (
+        motivoCompleto
+          .toLowerCase()
+          .startsWith('risco de contaminação cruzada')
+      ) {
+        grupo = 'Risco de Contaminação Cruzada';
+      }
+
+      if (!acc[grupo]) acc[grupo] = [];
+      acc[grupo].push(paciente);
+      return acc;
+    },
+    {} as Record<string, Paciente[]>
+  );
   const decisaoCirurgica = pacientesAguardandoRegulacao.filter(
     (p) => p.setorOrigem === "PS DECISÃO CIRURGICA"
   );


### PR DESCRIPTION
## Summary
- group remanejamentos by motive with special handling for cross-contamination risk
- collapse pending remanejamento block and subgroup sections into accordions with grid layout
- redesign remanejamento card to compact horizontal layout and hide cancel for contamination risk

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3168fb64483228fd4236f096fe900