### PR TITLE
fix: guard contamination grouping mutation

### DIFF
--- a/src/components/RemanejamentosPendentesBloco.tsx
+++ b/src/components/RemanejamentosPendentesBloco.tsx
@@ -34,11 +34,16 @@ export const RemanejamentosPendentesBloco = ({
           .startsWith("risco de contaminação cruzada")
       ) {
         motivoBase = "Risco de Contaminação Cruzada";
-        // Remove o prefixo para exibição no item
-        (paciente.motivoRemanejamento as any).detalhes = motivoCompleto.replace(
+        const detalhes = motivoCompleto.replace(
           /Risco de contaminação cruzada: /i,
           ""
         );
+        if (
+          paciente.motivoRemanejamento &&
+          typeof paciente.motivoRemanejamento === "object"
+        ) {
+          (paciente.motivoRemanejamento as any).detalhes = detalhes;
+        }
       }
       if (!acc[motivoBase]) acc[motivoBase] = [];
       acc[motivoBase].push(paciente);


### PR DESCRIPTION
## Summary
- prevent assigning properties to string contamination reasons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31fb83be48322a279f4227110320e