### PR TITLE
Refatora gestão de isolamentos e adiciona filtros avançados

### DIFF
--- a/src/components/FiltrosGestaoIsolamentos.tsx
+++ b/src/components/FiltrosGestaoIsolamentos.tsx
@@ -1,179 +1,116 @@
-
-import { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Badge } from '@/components/ui/badge';
-import { ChevronDown, ChevronUp, Search, Filter } from 'lucide-react';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSetores } from '@/hooks/useSetores';
 import { useIsolamentos } from '@/hooks/useIsolamentos';
 
-interface FiltrosGestaoIsolamentosProps {
-  busca: string;
-  setBusca: (busca: string) => void;
+interface Props {
   filtros: {
-    sexo: string;
+    nome: string;
     setor: string;
+    sexo: string;
     isolamentos: string[];
+    dias: string;
   };
-  setFiltros: (filtros: any) => void;
-  setores: any[];
+  setFiltros: React.Dispatch<React.SetStateAction<{
+    nome: string;
+    setor: string;
+    sexo: string;
+    isolamentos: string[];
+    dias: string;
+  }>>;
 }
 
-export const FiltrosGestaoIsolamentos = ({ 
-  busca, 
-  setBusca, 
-  filtros, 
-  setFiltros, 
-  setores 
-}: FiltrosGestaoIsolamentosProps) => {
-  const [filtroAvancadoAberto, setFiltroAvancadoAberto] = useState(false);
+const FiltrosGestaoIsolamentos = ({ filtros, setFiltros }: Props) => {
+  const { setores } = useSetores();
   const { isolamentos } = useIsolamentos();
 
-  const handleIsolamentoToggle = (isolamentoId: string, checked: boolean) => {
-    const novosIsolamentos = checked
-      ? [...filtros.isolamentos, isolamentoId]
-      : filtros.isolamentos.filter(id => id !== isolamentoId);
-    
-    setFiltros({
-      ...filtros,
-      isolamentos: novosIsolamentos
-    });
+  const handleMultiSelectChange = (id: string) => {
+    const current = filtros.isolamentos;
+    const isSelected = current.includes(id);
+    if (isSelected) {
+      setFiltros({ ...filtros, isolamentos: current.filter(isoId => isoId !== id) });
+    } else {
+      setFiltros({ ...filtros, isolamentos: [...current, id] });
+    }
   };
-
-  const limparFiltros = () => {
-    setFiltros({
-      sexo: '',
-      setor: '',
-      isolamentos: []
-    });
-    setBusca('');
-  };
-
-  const filtrosAtivos = [
-    filtros.sexo && 'Sexo',
-    filtros.setor && 'Setor',
-    filtros.isolamentos.length > 0 && 'Isolamentos'
-  ].filter(Boolean).length;
 
   return (
-    <Card className="shadow-card border border-border/50">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Filter className="h-5 w-5" />
-          Filtros
-          {filtrosAtivos > 0 && (
-            <Badge variant="secondary">{filtrosAtivos} ativo{filtrosAtivos > 1 ? 's' : ''}</Badge>
-          )}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Buscar por nome do paciente ou número do leito..."
-            value={busca}
-            onChange={(e) => setBusca(e.target.value)}
-            className="pl-10"
-          />
-        </div>
-
-        <Collapsible open={filtroAvancadoAberto} onOpenChange={setFiltroAvancadoAberto}>
-          <CollapsibleTrigger asChild>
-            <Button variant="outline" className="w-full justify-between">
-              <span className="flex items-center gap-2">
-                <Filter className="h-4 w-4" />
-                Filtros Avançados
-              </span>
-              {filtroAvancadoAberto ? (
-                <ChevronUp className="h-4 w-4" />
-              ) : (
-                <ChevronDown className="h-4 w-4" />
-              )}
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="space-y-4 mt-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="sexo-filter">Sexo</Label>
-                <Select 
-                  value={filtros.sexo} 
-                  onValueChange={(value) => setFiltros({...filtros, sexo: value})}
-                >
-                  <SelectTrigger id="sexo-filter">
-                    <SelectValue placeholder="Selecione o sexo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="todos">Todos</SelectItem>
-                    <SelectItem value="Masculino">Masculino</SelectItem>
-                    <SelectItem value="Feminino">Feminino</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <Label htmlFor="setor-filter">Setor</Label>
-                <Select 
-                  value={filtros.setor} 
-                  onValueChange={(value) => setFiltros({...filtros, setor: value})}
-                >
-                  <SelectTrigger id="setor-filter">
-                    <SelectValue placeholder="Selecione o setor" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="todos">Todos os setores</SelectItem>
-                    {setores.map(setor => (
-                      <SelectItem key={setor.id} value={setor.nomeSetor}>
-                        {setor.nomeSetor}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div>
-              <Label>Isolamentos Ativos</Label>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-2 max-h-32 overflow-y-auto">
-                {isolamentos.map(isolamento => (
-                  <div key={isolamento.id} className="flex items-center space-x-2">
-                    <Checkbox
-                      id={`isolamento-${isolamento.id}`}
-                      checked={filtros.isolamentos.includes(isolamento.id!)}
-                      onCheckedChange={(checked) => 
-                        handleIsolamentoToggle(isolamento.id!, !!checked)
-                      }
-                    />
-                    <Label 
-                      htmlFor={`isolamento-${isolamento.id}`}
-                      className="flex items-center gap-2 cursor-pointer"
+    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+      <Input
+        placeholder="Buscar por nome..."
+        value={filtros.nome}
+        onChange={(e) => setFiltros(prev => ({ ...prev, nome: e.target.value }))}
+      />
+      <Select value={filtros.setor} onValueChange={(v) => setFiltros(prev => ({ ...prev, setor: v }))}>
+        <SelectTrigger>
+          <SelectValue placeholder="Setor" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="todos">Todos</SelectItem>
+          {setores.map(setor => (
+            <SelectItem key={setor.id} value={setor.id!}>{setor.nomeSetor}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={filtros.sexo} onValueChange={(v) => setFiltros(prev => ({ ...prev, sexo: v }))}>
+        <SelectTrigger>
+          <SelectValue placeholder="Sexo" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="todos">Todos</SelectItem>
+          <SelectItem value="Masculino">Masculino</SelectItem>
+          <SelectItem value="Feminino">Feminino</SelectItem>
+        </SelectContent>
+      </Select>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" className="justify-start font-normal">
+            {filtros.isolamentos.length > 0 ? `${filtros.isolamentos.length} selecionado(s)` : 'Tipo de Isolamento'}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Buscar isolamento..." />
+            <CommandList>
+              <CommandEmpty>Nenhum isolamento encontrado.</CommandEmpty>
+              <CommandGroup>
+                {isolamentos.map(iso => (
+                  <CommandItem
+                    key={iso.id}
+                    value={iso.nomeMicroorganismo}
+                    onSelect={() => handleMultiSelectChange(iso.id!)}
+                  >
+                    <div
+                      className={cn(
+                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                        filtros.isolamentos.includes(iso.id!) ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible'
+                      )}
                     >
-                      <div 
-                        className="w-3 h-3 rounded-full" 
-                        style={{ backgroundColor: isolamento.cor }}
-                      />
-                      <span className="text-sm">{isolamento.sigla}</span>
-                    </Label>
-                  </div>
+                      <Check className="h-4 w-4" />
+                    </div>
+                    <Badge style={{ backgroundColor: iso.cor, color: 'white' }} className="mr-2 text-xs border-none">{iso.sigla}</Badge>
+                    <span>{iso.nomeMicroorganismo}</span>
+                  </CommandItem>
                 ))}
-              </div>
-            </div>
-
-            <div className="flex gap-2">
-              <Button 
-                variant="outline" 
-                onClick={limparFiltros}
-                className="flex-1"
-              >
-                Limpar Filtros
-              </Button>
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      </CardContent>
-    </Card>
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      <Input
+        type="number"
+        placeholder="Tempo (dias)"
+        value={filtros.dias}
+        onChange={(e) => setFiltros(prev => ({ ...prev, dias: e.target.value }))}
+      />
+    </div>
   );
 };
+
+export default FiltrosGestaoIsolamentos;


### PR DESCRIPTION
## Summary
- Permite definir status e data individual para cada isolamento selecionado
- Corrige exibição de múltiplos isolamentos suspeitos
- Adiciona painel de filtros na gestão de isolamentos
- Corrige selects de setor e sexo com valor "todos" e ajusta lógica de filtragem

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 879 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4a086f47c832299324c6d494a076d