### PR TITLE
feat: enhance bed map filters and inputs

### DIFF
--- a/src/components/FiltrosMapaLeitos.tsx
+++ b/src/components/FiltrosMapaLeitos.tsx
@@ -26,6 +26,9 @@ interface FiltrosMapaLeitosProps {
     status: string;
     provavelAlta: string;
     aguardaUTI: string;
+    pcp: string;
+    altaNoLeito: string;
+    solicitacaoRemanejamento: string;
     isolamentos: string[];
   };
   setFiltrosAvancados: (filtros: any) => void;
@@ -157,8 +160,40 @@ export const FiltrosMapaLeitos = ({
                   <SelectItem value="nao">Não</SelectItem>
                 </SelectContent>
               </Select>
-            </div>
+              <Select value={filtrosAvancados.pcp} onValueChange={(v) => setFiltrosAvancados({...filtrosAvancados, pcp: v})}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Leito PCP?" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="todos">Todos</SelectItem>
+                  <SelectItem value="sim">Sim</SelectItem>
+                  <SelectItem value="nao">Não</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={filtrosAvancados.altaNoLeito} onValueChange={(v) => setFiltrosAvancados({...filtrosAvancados, altaNoLeito: v})}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Alta no Leito?" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="todos">Todos</SelectItem>
+                  <SelectItem value="sim">Sim</SelectItem>
+                  <SelectItem value="nao">Não</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={filtrosAvancados.solicitacaoRemanejamento} onValueChange={(v) => setFiltrosAvancados({...filtrosAvancados, solicitacaoRemanejamento: v})}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Solicitação de Remanejamento?" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="todos">Todos</SelectItem>
+                  <SelectItem value="sim">Sim</SelectItem>
+                  <SelectItem value="nao">Não</SelectItem>
+                </SelectContent>
+              </Select>
             
+                </div>
             <div className="lg:col-span-3">
               <Label>Isolamento</Label>
               <Popover>

--- a/src/components/LeitoCard.tsx
+++ b/src/components/LeitoCard.tsx
@@ -112,7 +112,7 @@ const LeitoCard = ({ leito, todosLeitosDoSetor, actions }: LeitoCardProps) => {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <User className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                    <p className="font-medium text-sm leading-tight truncate">{paciente.nomeCompleto}</p>
+                    <p className="font-semibold text-sm truncate" title={paciente.nomeCompleto}>{paciente.nomeCompleto}</p>
                   </div>
                   {/* ÍCONES DE STATUS DO PACIENTE */}
                   <div className="flex items-center space-x-1">

--- a/src/components/modals/AdicionarEditarReservaModal.tsx
+++ b/src/components/modals/AdicionarEditarReservaModal.tsx
@@ -23,6 +23,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
 import { ReservaOncologia } from '@/types/reservaOncologia';
+import { formatarInputData } from '@/lib/utils';
 
 const schema = z.object({
   nomeCompleto: z.string().min(1, 'Nome é obrigatório'),
@@ -97,7 +98,7 @@ export const AdicionarEditarReservaModal = ({ open, onOpenChange, onSubmit, rese
                 <FormItem>
                   <FormLabel>Nome Completo</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} onChange={(e) => field.onChange(e.target.value.toUpperCase())} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -111,7 +112,7 @@ export const AdicionarEditarReservaModal = ({ open, onOpenChange, onSubmit, rese
                 <FormItem>
                   <FormLabel>Data de Nascimento</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} maxLength={10} onChange={(e) => field.onChange(formatarInputData(e.target.value))} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -162,7 +163,7 @@ export const AdicionarEditarReservaModal = ({ open, onOpenChange, onSubmit, rese
                 <FormItem>
                   <FormLabel>Data Prevista Internação</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} maxLength={10} onChange={(e) => field.onChange(formatarInputData(e.target.value))} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/hooks/useFiltrosMapaLeitos.ts
+++ b/src/hooks/useFiltrosMapaLeitos.ts
@@ -13,6 +13,9 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
     status: '',
     provavelAlta: '',
     aguardaUTI: '',
+    pcp: 'todos',
+    altaNoLeito: 'todos',
+    solicitacaoRemanejamento: 'todos',
     isolamentos: [] as string[],
   });
 
@@ -41,9 +44,13 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
     }
 
     // 2. Filtros Avançados
-    const { especialidade, setor, sexo, status, provavelAlta, aguardaUTI, isolamentos } = filtrosAvancados;
+    const { especialidade, setor, sexo, status, provavelAlta, aguardaUTI, pcp, altaNoLeito, solicitacaoRemanejamento, isolamentos } = filtrosAvancados;
 
-    if (especialidade || setor || sexo || status || provavelAlta || aguardaUTI || isolamentos.length > 0) {
+      if (
+        especialidade || setor || sexo || status || provavelAlta || aguardaUTI ||
+        pcp !== 'todos' || altaNoLeito !== 'todos' || solicitacaoRemanejamento !== 'todos' ||
+        isolamentos.length > 0
+      ) {
       setoresFiltrados = setoresFiltrados
         .map(s => {
           const leitosFiltrados = s.leitos.filter(l => {
@@ -86,6 +93,18 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
               const deveAguardarUTI = aguardaUTI === 'sim';
               if (!!l.dadosPaciente?.aguardaUTI !== deveAguardarUTI) return false;
             }
+            // Filtro PCP
+            if (pcp === 'sim' && !l.leitoPCP) return false;
+            if (pcp === 'nao' && l.leitoPCP) return false;
+
+            // Filtro Alta no Leito
+            if (altaNoLeito === 'sim' && !l.dadosPaciente?.altaNoLeito) return false;
+            if (altaNoLeito === 'nao' && l.dadosPaciente?.altaNoLeito) return false;
+
+            // Filtro Remanejamento
+            if (solicitacaoRemanejamento === 'sim' && !l.dadosPaciente?.remanejarPaciente) return false;
+            if (solicitacaoRemanejamento === 'nao' && l.dadosPaciente?.remanejarPaciente) return false;
+
 
             if (especialidade && l.dadosPaciente?.especialidadePaciente !== especialidade) return false;
             if (isolamentos.length > 0) {
@@ -104,7 +123,7 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
 
   const resetFiltros = () => {
     setSearchTerm('');
-    setFiltrosAvancados({ especialidade: '', setor: '', sexo: '', status: '', provavelAlta: '', aguardaUTI: '', isolamentos: [] });
+    setFiltrosAvancados({ especialidade: '', setor: '', sexo: '', status: '', provavelAlta: '', aguardaUTI: '', pcp: 'todos', altaNoLeito: 'todos', solicitacaoRemanejamento: 'todos', isolamentos: [] });
   };
   
   return { 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,3 +101,9 @@ export const descreverMotivoRemanejamento = (
       return '';
   }
 };
+export const formatarInputData = (valor: string): string => {
+  const digitos = valor.replace(/\D/g, '');
+  if (digitos.length <= 2) return digitos;
+  if (digitos.length <= 4) return `${digitos.slice(0, 2)}/${digitos.slice(2)}`;
+  return `${digitos.slice(0, 2)}/${digitos.slice(2, 4)}/${digitos.slice(4, 8)}`;
+};


### PR DESCRIPTION
## Summary
- enforce uppercase name and date masks in oncology reservation modal
- extend bed map advanced filters for PCP, alta no leito and remanejamento
- truncate patient name in bed cards to prevent overflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a84516708322ae63a58e1dacaed5