### PR TITLE
Ajusta placeholders e filtro de transferência externa no mapa de leitos

### DIFF
--- a/src/components/FiltrosMapaLeitos.tsx
+++ b/src/components/FiltrosMapaLeitos.tsx
@@ -29,6 +29,7 @@ interface FiltrosMapaLeitosProps {
     pcp: string;
     altaNoLeito: string;
     solicitacaoRemanejamento: string;
+    transferenciaExterna: string;
     isolamentos: string[];
   };
   setFiltrosAvancados: (filtros: any) => void;
@@ -165,7 +166,6 @@ export const FiltrosMapaLeitos = ({
                   <SelectValue placeholder="Leito PCP?" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="todos">Todos</SelectItem>
                   <SelectItem value="sim">Sim</SelectItem>
                   <SelectItem value="nao">Não</SelectItem>
                 </SelectContent>
@@ -176,7 +176,6 @@ export const FiltrosMapaLeitos = ({
                   <SelectValue placeholder="Alta no Leito?" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="todos">Todos</SelectItem>
                   <SelectItem value="sim">Sim</SelectItem>
                   <SelectItem value="nao">Não</SelectItem>
                 </SelectContent>
@@ -187,7 +186,16 @@ export const FiltrosMapaLeitos = ({
                   <SelectValue placeholder="Solicitação de Remanejamento?" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="todos">Todos</SelectItem>
+                  <SelectItem value="sim">Sim</SelectItem>
+                  <SelectItem value="nao">Não</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={filtrosAvancados.transferenciaExterna} onValueChange={(v) => setFiltrosAvancados({...filtrosAvancados, transferenciaExterna: v})}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Transf. Externa?" />
+                </SelectTrigger>
+                <SelectContent>
                   <SelectItem value="sim">Sim</SelectItem>
                   <SelectItem value="nao">Não</SelectItem>
                 </SelectContent>

--- a/src/hooks/useFiltrosMapaLeitos.ts
+++ b/src/hooks/useFiltrosMapaLeitos.ts
@@ -13,9 +13,10 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
     status: '',
     provavelAlta: '',
     aguardaUTI: '',
-    pcp: 'todos',
-    altaNoLeito: 'todos',
-    solicitacaoRemanejamento: 'todos',
+    pcp: '',
+    altaNoLeito: '',
+    solicitacaoRemanejamento: '',
+    transferenciaExterna: '',
     isolamentos: [] as string[],
   });
 
@@ -44,11 +45,11 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
     }
 
     // 2. Filtros Avançados
-    const { especialidade, setor, sexo, status, provavelAlta, aguardaUTI, pcp, altaNoLeito, solicitacaoRemanejamento, isolamentos } = filtrosAvancados;
+    const { especialidade, setor, sexo, status, provavelAlta, aguardaUTI, pcp, altaNoLeito, solicitacaoRemanejamento, transferenciaExterna, isolamentos } = filtrosAvancados;
 
       if (
         especialidade || setor || sexo || status || provavelAlta || aguardaUTI ||
-        pcp !== 'todos' || altaNoLeito !== 'todos' || solicitacaoRemanejamento !== 'todos' ||
+        pcp || altaNoLeito || solicitacaoRemanejamento || transferenciaExterna ||
         isolamentos.length > 0
       ) {
       setoresFiltrados = setoresFiltrados
@@ -105,6 +106,10 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
             if (solicitacaoRemanejamento === 'sim' && !l.dadosPaciente?.remanejarPaciente) return false;
             if (solicitacaoRemanejamento === 'nao' && l.dadosPaciente?.remanejarPaciente) return false;
 
+            // Filtro Transferência Externa
+            if (transferenciaExterna === 'sim' && !l.dadosPaciente?.transferirPaciente) return false;
+            if (transferenciaExterna === 'nao' && l.dadosPaciente?.transferirPaciente) return false;
+
 
             if (especialidade && l.dadosPaciente?.especialidadePaciente !== especialidade) return false;
             if (isolamentos.length > 0) {
@@ -123,7 +128,7 @@ export const useFiltrosMapaLeitos = (setores: SetorComLeitos[]) => {
 
   const resetFiltros = () => {
     setSearchTerm('');
-    setFiltrosAvancados({ especialidade: '', setor: '', sexo: '', status: '', provavelAlta: '', aguardaUTI: '', pcp: 'todos', altaNoLeito: 'todos', solicitacaoRemanejamento: 'todos', isolamentos: [] });
+    setFiltrosAvancados({ especialidade: '', setor: '', sexo: '', status: '', provavelAlta: '', aguardaUTI: '', pcp: '', altaNoLeito: '', solicitacaoRemanejamento: '', transferenciaExterna: '', isolamentos: [] });
   };
   
   return { 


### PR DESCRIPTION
## Summary
- Corrige estado inicial dos filtros para exibir placeholders e inclui novo campo `transferenciaExterna`
- Aplica lógica de filtragem para transferência externa e reseta novos campos ao limpar filtros
- Remove opção "Todos" dos filtros recentes e adiciona seletor de transferência externa na interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and related errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4ada11f648322a32a682a1e3c94ed