### PR TITLE
feat: agrupamento e cópia no relatório de especialidades

### DIFF
--- a/src/components/modals/RelatorioEspecialidadeModal.tsx
+++ b/src/components/modals/RelatorioEspecialidadeModal.tsx
@@ -1,6 +1,17 @@
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Badge } from "@/components/ui/badge";
+import { useMemo } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Copy } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
 
 interface RelatorioEspecialidadeModalProps {
   open: boolean;
@@ -9,7 +20,49 @@ interface RelatorioEspecialidadeModalProps {
 }
 
 export const RelatorioEspecialidadeModal = ({ open, onOpenChange, dadosOcupacao }: RelatorioEspecialidadeModalProps) => {
-  const entries = Object.entries(dadosOcupacao).sort(([a], [b]) => a.localeCompare(b));
+  const { toast } = useToast();
+
+  const especialidadesContagemOrdenada = useMemo(() => {
+    const contagemAgrupada = Object.entries(dadosOcupacao).reduce(
+      (acc, [esp, contagem]) => {
+        let especialidade = esp;
+        if (especialidade === 'BUCOMAXILO') {
+          especialidade = 'ODONTOLOGIA C.TRAUM.B.M.F.';
+        } else if (especialidade === 'INTENSIVISTA') {
+          especialidade = 'CLINICA GERAL';
+        }
+        acc[especialidade] = (acc[especialidade] || 0) + contagem;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+    return Object.entries(contagemAgrupada).sort(([a], [b]) => a.localeCompare(b));
+  }, [dadosOcupacao]);
+
+  const handleCopiar = () => {
+    const textoLista = especialidadesContagemOrdenada
+      .map(([especialidade, contagem]) => `${especialidade}: ${contagem}`)
+      .join('\n');
+
+    const textoCompleto = `Ocupação por Especialidade\nQuantidade de pacientes internados por especialidade.\n\n${textoLista}`;
+
+    navigator.clipboard
+      .writeText(textoCompleto)
+      .then(() => {
+        toast({
+          title: 'Copiado!',
+          description: 'O relatório de ocupação foi copiado para a área de transferência.',
+        });
+      })
+      .catch((err) => {
+        console.error('Erro ao copiar texto: ', err);
+        toast({
+          title: 'Erro',
+          description: 'Não foi possível copiar o relatório.',
+          variant: 'destructive',
+        });
+      });
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -21,9 +74,9 @@ export const RelatorioEspecialidadeModal = ({ open, onOpenChange, dadosOcupacao 
           </DialogDescription>
         </DialogHeader>
         <ScrollArea className="max-h-72 pr-4">
-          {entries.length > 0 ? (
+          {especialidadesContagemOrdenada.length > 0 ? (
             <ul className="space-y-2">
-              {entries.map(([especialidade, contagem]) => (
+              {especialidadesContagemOrdenada.map(([especialidade, contagem]) => (
                 <li key={especialidade} className="flex items-center justify-between">
                   <span>{especialidade}</span>
                   <Badge variant="secondary">{contagem}</Badge>
@@ -34,6 +87,13 @@ export const RelatorioEspecialidadeModal = ({ open, onOpenChange, dadosOcupacao 
             <p className="text-center text-sm text-muted-foreground">Sem internações</p>
           )}
         </ScrollArea>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCopiar}>
+            <Copy className="mr-2 h-4 w-4" />
+            Copiar
+          </Button>
+          <Button onClick={() => onOpenChange(false)}>Fechar</Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- agrupa BUCOMAXILO e INTENSIVISTA em suas especialidades correspondentes
- adiciona botão para copiar relatório de ocupação por especialidade

## Testing
- `npm run lint` *(fails: Unexpected any... and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8521eb3b88322afa9ffdc2e41adbc