### PR TITLE
feat: add client-side cache for Firestore semi-static data

### DIFF
--- a/src/contexts/CacheContext.tsx
+++ b/src/contexts/CacheContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, ReactNode, useState, useEffect } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { Setor } from '@/types/hospital';
+import { TipoIsolamento } from '@/types/isolamento';
+
+interface CacheContextData {
+  setores: Setor[];
+  tiposDeIsolamento: TipoIsolamento[];
+  loading: boolean;
+}
+
+const CacheContext = createContext<CacheContextData>({} as CacheContextData);
+
+export const CacheProvider = ({ children }: { children: ReactNode }) => {
+  const [setores, setSetores] = useState<Setor[]>([]);
+  const [tiposDeIsolamento, setTiposDeIsolamento] = useState<TipoIsolamento[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+
+    const setoresCached = localStorage.getItem('cache_setores');
+    const isolamentosCached = localStorage.getItem('cache_isolamentos');
+
+    if (setoresCached) setSetores(JSON.parse(setoresCached));
+    if (isolamentosCached) setTiposDeIsolamento(JSON.parse(isolamentosCached));
+
+    const unsubSetores = onSnapshot(collection(db, 'setoresRegulaFacil'), (snapshot) => {
+      const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as Setor[];
+      setSetores(data);
+      localStorage.setItem('cache_setores', JSON.stringify(data));
+      setLoading(false);
+    });
+
+    const unsubIsolamentos = onSnapshot(collection(db, 'isolamentosRegulaFacil'), (snapshot) => {
+      const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as TipoIsolamento[];
+      setTiposDeIsolamento(data);
+      localStorage.setItem('cache_isolamentos', JSON.stringify(data));
+    });
+
+    return () => {
+      unsubSetores();
+      unsubIsolamentos();
+    };
+  }, []);
+
+  return (
+    <CacheContext.Provider value={{ setores, tiposDeIsolamento, loading }}>
+      {children}
+    </CacheContext.Provider>
+  );
+};
+
+export const useCache = () => {
+  return useContext(CacheContext);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,13 @@
-
 import React from 'react';
-import { createRoot } from 'react-dom/client';
+import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { CacheProvider } from './contexts/CacheContext';
 
-createRoot(document.getElementById("root")!).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <CacheProvider>
+      <App />
+    </CacheProvider>
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- add CacheContext with localStorage-backed caching for setores and isolamentos
- wrap app in CacheProvider
- refactor hooks to consume cached data while preserving create/update/delete operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b85aa6c4188322acaca4c797e35e35