### PR TITLE
feat: add contra fluxo option to bed finder

### DIFF
--- a/src/components/RemanejamentosPendentesBloco.tsx
+++ b/src/components/RemanejamentosPendentesBloco.tsx
@@ -2,7 +2,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { RemanejamentoPendenteItem } from "@/components/RemanejamentoPendenteItem";
-import { Paciente } from "@/types/hospital";
+import { Paciente, DetalhesRemanejamento } from "@/types/hospital";
 import { descreverMotivoRemanejamento } from "@/lib/utils";
 import {
   Accordion,
@@ -13,7 +13,7 @@ import {
 
 interface RemanejamentosPendentesBlocoProps {
   remanejamentos: Paciente[];
-  onRemanejar: (paciente: Paciente) => void;
+  onRemanejar: (paciente: Paciente, opcoes?: { isContraFluxo?: boolean }) => void;
   onCancelar: (paciente: Paciente) => void;
 }
 
@@ -22,6 +22,12 @@ export const RemanejamentosPendentesBloco = ({
   onRemanejar,
   onCancelar,
 }: RemanejamentosPendentesBlocoProps) => {
+  const handleRemanejar = (paciente: Paciente) => {
+    const isContraFluxo =
+      (paciente.motivoRemanejamento as DetalhesRemanejamento)?.tipo ===
+      "contra_fluxo";
+    onRemanejar(paciente, { isContraFluxo });
+  };
   const grupos = remanejamentos.reduce(
     (acc, paciente) => {
       const motivoCompleto = descreverMotivoRemanejamento(
@@ -85,7 +91,7 @@ export const RemanejamentosPendentesBloco = ({
                           <RemanejamentoPendenteItem
                             key={paciente.id}
                             paciente={paciente}
-                            onRemanejar={onRemanejar}
+                            onRemanejar={handleRemanejar}
                             onCancelar={onCancelar}
                           />
                         ))}

--- a/src/components/modals/RegulacaoModal.tsx
+++ b/src/components/modals/RegulacaoModal.tsx
@@ -29,6 +29,7 @@ interface RegulacaoModalProps {
   onConfirmRegulacao: (leitoDestino: any, observacoes: string, motivoAlteracao?: string) => void;
   isAlteracao?: boolean;
   modo?: 'normal' | 'uti';
+  opcoes?: { isContraFluxo?: boolean };
 }
 
 const calcularIdade = (dataNascimento?: string): string => {
@@ -40,7 +41,7 @@ const calcularIdade = (dataNascimento?: string): string => {
     return idade.toString();
 };
 
-export const RegulacaoModal = ({ open, onOpenChange, paciente, origem, onConfirmRegulacao, isAlteracao = false, modo = 'normal' }: RegulacaoModalProps) => {
+export const RegulacaoModal = ({ open, onOpenChange, paciente, origem, onConfirmRegulacao, isAlteracao = false, modo = 'normal', opcoes = {} }: RegulacaoModalProps) => {
   const { findAvailableLeitos } = useLeitoFinder();
   const { toast } = useToast();
   const [leitosDisponiveis, setLeitosDisponiveis] = useState<LeitoCompativel[]>([]);
@@ -68,7 +69,7 @@ export const RegulacaoModal = ({ open, onOpenChange, paciente, origem, onConfirm
 
   useEffect(() => {
     if (open && paciente) {
-      setLeitosDisponiveis(findAvailableLeitos(paciente, modo));
+      setLeitosDisponiveis(findAvailableLeitos(paciente, modo, opcoes));
     }
     if (!open) {
       setEtapa(isAlteracao ? 0 : 1);
@@ -76,7 +77,7 @@ export const RegulacaoModal = ({ open, onOpenChange, paciente, origem, onConfirm
       setObservacoes('');
       setMotivoAlteracao('');
     }
-  }, [open, paciente, findAvailableLeitos, isAlteracao, modo]);
+  }, [open, paciente, findAvailableLeitos, isAlteracao, modo, opcoes]);
 
   const leitosAgrupadosPorSetor = useMemo(() => {
     return leitosDisponiveis.reduce((acc, leito) => {

--- a/src/components/modals/regulacao/RegulacaoModals.tsx
+++ b/src/components/modals/regulacao/RegulacaoModals.tsx
@@ -33,6 +33,7 @@ interface RegulacaoModalsProps {
   pacientesRegulados: any[];
   sugestoes: any[];
   totalPendentes: number;
+  opcoes?: { isContraFluxo?: boolean };
   
   // Handlers
   onProcessFileRequest: (file: File) => void;
@@ -74,6 +75,7 @@ export const RegulacaoModals = ({
   pacientesRegulados,
   sugestoes,
   totalPendentes,
+  opcoes,
   onProcessFileRequest,
   onConfirmSync,
   onConfirmarRegulacao,
@@ -110,6 +112,7 @@ export const RegulacaoModals = ({
         onConfirmRegulacao={onConfirmarRegulacao}
         isAlteracao={isAlteracaoMode}
         modo={modoRegulacao}
+        opcoes={opcoes}
       />
 
       <CancelamentoModal

--- a/src/hooks/useRegulacaoLogic.ts
+++ b/src/hooks/useRegulacaoLogic.ts
@@ -67,6 +67,7 @@ export const useRegulacaoLogic = () => {
   const [syncSummary, setSyncSummary] = useState<SyncSummary | null>(null);
   const [dadosPlanilhaProcessados, setDadosPlanilhaProcessados] = useState<PacienteDaPlanilha[]>([]);
   const [modoRegulacao, setModoRegulacao] = useState<"normal" | "uti">("normal");
+  const [opcoesRegulacao, setOpcoesRegulacao] = useState<{ isContraFluxo?: boolean }>({});
   const [processing, setProcessing] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
 
@@ -480,7 +481,8 @@ const registrarHistoricoRegulacao = async (
   // Funções de Ação
   const handleOpenRegulacaoModal = (
     paciente: any,
-    modo: "normal" | "uti" = "normal"
+    modo: "normal" | "uti" = "normal",
+    opcoes: { isContraFluxo?: boolean } = {}
   ) => {
     // 1. Define o Paciente-Alvo:
     // Coloca o paciente que precisa ser remanejado no estado `pacienteParaRegular`.
@@ -488,6 +490,9 @@ const registrarHistoricoRegulacao = async (
 
     // 2. Define o Modo: Garante que o modal abra no modo "normal" (não de UTI).
     setModoRegulacao(modo);
+
+    // 2.1. Define opções adicionais para a regulação
+    setOpcoesRegulacao(opcoes);
 
     // 3. Reseta o Estado de Alteração: Garante que não está no modo de "alterar" regulação.
     setIsAlteracaoMode(false);
@@ -1562,6 +1567,7 @@ const registrarHistoricoRegulacao = async (
       validationResult,
       syncSummary,
       modoRegulacao,
+      opcoesRegulacao,
       actingOnPatientId,
     },
 

--- a/src/pages/RegulacaoLeitos.tsx
+++ b/src/pages/RegulacaoLeitos.tsx
@@ -301,8 +301,8 @@ const RegulacaoLeitos = () => {
         {/* 7. Bloco: Remanejamentos Pendentes */}
         <RemanejamentosPendentesBloco
           remanejamentos={listas.remanejamentosPendentes}
-          onRemanejar={(paciente) =>
-            handlers.handleOpenRegulacaoModal(paciente, "normal")
+          onRemanejar={(paciente, opcoes) =>
+            handlers.handleOpenRegulacaoModal(paciente, "normal", opcoes)
           }
           onCancelar={handlers.handleCancelarRemanejamento}
         />
@@ -335,6 +335,7 @@ const RegulacaoLeitos = () => {
           pacientesRegulados={listas.pacientesJaRegulados}
           sugestoes={listas.sugestoesDeRegulacao}
           totalPendentes={listas.totalPendentes}
+          opcoes={modals.opcoesRegulacao}
           onProcessFileRequest={handlers.handleProcessFileRequest}
           onConfirmSync={handlers.handleConfirmSync}
           onConfirmarRegulacao={handleConfirmarRegulacao}


### PR DESCRIPTION
## Summary
- forward contra-fluxo flag from pending relocations into regulation modal
- add contra-fluxo search path in bed finder returning only emergency beds
- plumb option through regulation flow and UI

## Testing
- `npm run lint` *(fails: 880 problems - Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b86514c4b08322a4c7a001e8d7f578