### PR TITLE
refactor: centralize bed sex logic

### DIFF
--- a/src/hooks/useLeitoFinder.ts
+++ b/src/hooks/useLeitoFinder.ts
@@ -1,9 +1,9 @@
 
-import { useMemo, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useSetores } from './useSetores';
 import { Leito, DadosPaciente, HistoricoLeito } from '@/types/hospital';
 import { parse, differenceInHours, isValid } from 'date-fns';
-import { getQuartoId } from '@/lib/utils';
+import { getQuartoId, determinarSexoLeito, isQuartoUTQ } from '@/lib/utils';
 
 export interface LeitoCompativel extends Leito {
   setorNome: string;
@@ -33,30 +33,6 @@ const calcularIdade = (dataNascimento: string): number => {
   return idade;
 };
 
-// Identifica se o leito pertence ao quarto 504 da Clínica Médica (UTQ)
-const isQuartoUTQ = (leito: { setorNome: string; codigoLeito: string }): boolean => {
-    return (
-        leito.setorNome === 'UNID. CLINICA MEDICA' &&
-        getQuartoId(leito.codigoLeito).startsWith('504')
-    );
-};
-
-// Nova função para determinar o sexo compatível para um leito
-const determinarSexoLeito = (leito: any, todosLeitosComSetor: any[]): 'Masculino' | 'Feminino' | 'Ambos' => {
-    if (isQuartoUTQ(leito)) return 'Ambos';
-    const quartoId = getQuartoId(leito.codigoLeito);
-    const companheirosDeQuarto = todosLeitosComSetor.filter(
-        l => getQuartoId(l.codigoLeito) === quartoId && l.statusLeito === 'Ocupado' && l.dadosPaciente
-    );
-
-    if (companheirosDeQuarto.length === 0) {
-        return 'Ambos'; // Quarto vazio, pode receber qualquer sexo
-    }
-
-    // Pega o sexo do primeiro paciente do quarto (todos devem ter o mesmo sexo)
-    const sexoQuarto = companheirosDeQuarto[0].dadosPaciente?.sexoPaciente;
-    return sexoQuarto === 'Masculino' ? 'Masculino' : 'Feminino';
-};
 
 // Nova função para priorizar pacientes
 const priorizarPacientes = (pacientes: any[]): any[] => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -123,3 +123,31 @@ export const getQuartoId = (codigoLeito: string): string => {
   // Fallback para casos onde o código não começa com número.
   return codigoLeito;
 };
+
+export const isQuartoUTQ = (leito: { setorNome: string; codigoLeito: string }): boolean => {
+  return (
+    leito.setorNome === 'UNID. CLINICA MEDICA' &&
+    getQuartoId(leito.codigoLeito).startsWith('504')
+  );
+};
+
+export const determinarSexoLeito = (
+  leito: any,
+  todosLeitosComSetor: any[]
+): 'Masculino' | 'Feminino' | 'Ambos' => {
+  if (isQuartoUTQ(leito)) return 'Ambos';
+  const quartoId = getQuartoId(leito.codigoLeito);
+  const companheirosDeQuarto = todosLeitosComSetor.filter(
+    l =>
+      getQuartoId(l.codigoLeito) === quartoId &&
+      l.statusLeito === 'Ocupado' &&
+      l.dadosPaciente
+  );
+
+  if (companheirosDeQuarto.length === 0) {
+    return 'Ambos';
+  }
+
+  const sexoQuarto = companheirosDeQuarto[0].dadosPaciente?.sexoPaciente;
+  return sexoQuarto === 'Masculino' ? 'Masculino' : 'Feminino';
+};


### PR DESCRIPTION
## Summary
- centralize bed sex determination and UTQ checks in utils
- refactor leito finder and available-bed report to use shared utilities
- allow suggestion modal to compute bed compatibility with centralized helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68b875b405f08322b6dd84d3d6ee8282