### PR TITLE
Format ICU discharge destination codes

### DIFF
--- a/src/components/modals/BoletimDiarioModal.tsx
+++ b/src/components/modals/BoletimDiarioModal.tsx
@@ -56,6 +56,7 @@ export const BoletimDiarioModal = ({ open, onOpenChange, gerarTextoBoletim }: Bo
 
   const handleSubmit = (data: FormData) => {
     const t = gerarTextoBoletim(data);
+    // o texto já contém a formatação da previsão de altas da UTI, com "UTI" substituído por "L "
     setTexto(t);
     setStep(2);
   };

--- a/src/hooks/useBoletimDiario.ts
+++ b/src/hooks/useBoletimDiario.ts
@@ -112,7 +112,10 @@ export const useBoletimDiario = ({ pacientes: _pacientes, leitos, setores, nivel
       '🔴 PCP Nível 3\n✅ Focar na resolução das pendências na enfermaria! Acionar equipe residentes / Staff para auxiliar na tomada de decisão!\n✅ Selecionar os pacientes e realizar as transferências para o leito de PCP!\n✅ Altas planejadas, focar para o período matutino. Prioridade máxima',
   };
 
-  const formatarAltas = (lista: string[]) => (lista.length ? lista.join(', ') : 'SEM PREVISÃO DE ALTA');
+  const formatarAltas = (lista: string[]) =>
+    lista.length
+      ? lista.map((l) => l.replace(/^UTI\s*/i, 'L ')).join(', ')
+      : 'SEM PREVISÃO DE ALTA';
 
   const gerarTextoBoletim = (dados: DadosManuaisBoletim) => {
     const dataHora = new Date().toLocaleString('pt-BR');


### PR DESCRIPTION
## Summary
- format ICU discharge destinations by replacing leading "UTI" with "L " when generating the daily bulletin
- document the ICU formatting in the bulletin modal

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b7cbdc0832283701177772ba899