### PR TITLE
refactor: redesign audit logs page and filtering

### DIFF
--- a/src/hooks/useAuditoriaLogs.ts
+++ b/src/hooks/useAuditoriaLogs.ts
@@ -1,57 +1,130 @@
-
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react'
 import {
+  addDoc,
   collection,
-  onSnapshot,
-  query,
-  orderBy,
-  writeBatch,
   getDocs,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
   Timestamp,
-} from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+  writeBatch,
+} from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { useUsuarios } from './useUsuarios'
+import { useAuth } from './useAuth'
+import { toast } from '@/hooks/use-toast'
 
 export interface Log {
-  id: string;
-  usuario: string;
-  acao: string;
-  detalhes: string;
-  timestamp: Timestamp; // Firestore Timestamp
+  id: string
+  usuario: string
+  usuarioId: string | null
+  pagina: string
+  acao: string
+  timestamp: Timestamp
 }
 
-export const useAuditoriaLogs = () => {
-  const [logs, setLogs] = useState<Log[]>([]);
-  const [loading, setLoading] = useState(true);
+export interface FiltrosLogs {
+  texto: string
+  usuarioId: string
+  dataInicio: Date | null
+  dataFim: Date | null
+  pagina: string
+}
+
+export const useAuditoriaLogs = (filtros: FiltrosLogs) => {
+  const [todosLogs, setTodosLogs] = useState<Log[]>([])
+  const [loading, setLoading] = useState(true)
+  const { usuarios } = useUsuarios()
+  const { currentUser } = useAuth()
+
+  const mapaUsuarios = useMemo(() => {
+    const mapa = new Map<string, string>()
+    usuarios.forEach(u => {
+      if (u.uid) mapa.set(u.uid, u.nomeCompleto)
+    })
+    return mapa
+  }, [usuarios])
 
   useEffect(() => {
     const q = query(
       collection(db, 'auditoriaRegulaFacil'),
-      orderBy('timestamp', 'desc'),
-    );
+      orderBy('timestamp', 'desc')
+    )
     const unsubscribe = onSnapshot(q, snapshot => {
-      const logsData = snapshot.docs.map(
-        doc => ({ id: doc.id, ...(doc.data() as Omit<Log, 'id'>) }),
-      );
-      setLogs(logsData);
-      setLoading(false);
-    });
-    return () => unsubscribe();
-  }, []);
+      const logsData: Log[] = snapshot.docs.map(doc => {
+        const data = doc.data() as any
+        const uid = data.uid || data.usuarioId || null
+        const nomeUsuario = uid
+          ? mapaUsuarios.get(uid) || uid
+          : data.usuario || 'Sistema'
+        return {
+          id: doc.id,
+          usuario: nomeUsuario,
+          usuarioId: uid,
+          pagina: data.pagina || data.detalhes || '',
+          acao: data.acao || data.mensagem || '',
+          timestamp: data.timestamp,
+        }
+      })
+      setTodosLogs(logsData)
+      setLoading(false)
+    })
+    return () => unsubscribe()
+  }, [mapaUsuarios])
 
-  const deleteAllLogs = async () => {
-    setLoading(true);
+  const logs = useMemo(() => {
+    return todosLogs.filter(log => {
+      const dataLog = log.timestamp.toDate()
+      if (
+        filtros.texto &&
+        !log.acao.toLowerCase().includes(filtros.texto.toLowerCase()) &&
+        !log.pagina.toLowerCase().includes(filtros.texto.toLowerCase()) &&
+        !log.usuario.toLowerCase().includes(filtros.texto.toLowerCase())
+      ) {
+        return false
+      }
+      if (filtros.usuarioId && log.usuarioId !== filtros.usuarioId) return false
+      if (filtros.dataInicio && dataLog < filtros.dataInicio) return false
+      if (filtros.dataFim && dataLog > filtros.dataFim) return false
+      if (
+        filtros.pagina &&
+        !log.pagina.toLowerCase().includes(filtros.pagina.toLowerCase())
+      ) {
+        return false
+      }
+      return true
+    })
+  }, [todosLogs, filtros])
+
+  const limparTodosOsLogs = async () => {
+    setLoading(true)
     try {
-      const q = query(collection(db, 'auditoriaRegulaFacil'));
-      const snapshot = await getDocs(q);
-      const batch = writeBatch(db);
-      snapshot.docs.forEach(doc => batch.delete(doc.ref));
-      await batch.commit();
-    } catch (error) {
-      console.error("Erro ao deletar logs:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
+      const q = query(collection(db, 'auditoriaRegulaFacil'))
+      const snapshot = await getDocs(q)
+      const batch = writeBatch(db)
+      snapshot.docs.forEach(doc => batch.delete(doc.ref))
+      await batch.commit()
 
-  return { logs, loading, deleteAllLogs };
-};
+      await addDoc(collection(db, 'auditoriaRegulaFacil'), {
+        uid: currentUser?.uid || null,
+        pagina: 'Auditoria',
+        acao: 'Todos os logs foram limpos',
+        timestamp: serverTimestamp(),
+      })
+      toast({ title: 'Logs limpos com sucesso.' })
+    } catch (error) {
+      console.error('Erro ao limpar logs:', error)
+      toast({
+        title: 'Erro ao limpar logs',
+        description: 'Não foi possível limpar os registros.',
+        variant: 'destructive',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { logs, loading, limparTodosOsLogs }
+}
+


### PR DESCRIPTION
## Summary
- map audit log UID to user names and provide client-side filtering
- rebuild audit page with card layout, shadcn table, and admin-only log clearing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: dependency conflict with date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5721a9b48322828a34e73d95a982