### PR TITLE
fix: memoize remanejamento and handle null timestamps

### DIFF
--- a/src/hooks/useAuditoriaLogs.ts
+++ b/src/hooks/useAuditoriaLogs.ts
@@ -84,6 +84,10 @@ export const useAuditoriaLogs = (filtros: FiltrosLogs) => {
 
   const logs = useMemo(() => {
     return todosLogs.filter(log => {
+      if (!log.timestamp) {
+        return false
+      }
+
       const dataLog = log.timestamp.toDate()
       if (
         filtros.texto &&


### PR DESCRIPTION
## Summary
- memoize remanejamento request function to avoid useEffect loops
- guard against missing timestamps when filtering audit logs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ba6636b8e083229e9d4c71817ac5c4